### PR TITLE
Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+# based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Dependencies
+        run: python -m pip install --upgrade build
+      - name: Build
+        run: python3 -m build
+      - name: Store packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/maturin-import-hook
+    permissions:
+      id-token: write
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build]
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/Contributing.md
+++ b/Contributing.md
@@ -43,3 +43,12 @@ of those linters.
 The configuration starts with all `ruff` lints enabled with a list of specifically disabled lints.
 If you are writing new code that is triggering a lint that you think ought to be disabled, you can suggest this in
 a PR, but generally stick to conforming to the suggested linter rules.
+
+## Making a release
+
+1. Bump the version number in `pyproject.toml`.
+2. Update `Changelog.md` to reflect the new changes.
+3. Check out the commit you want to make a release from.
+4. Run `git tag <version>` e.g. `git tag v0.1.0`.
+5. Run `git push origin <version>` e.g. `git tag v0.1.0`.
+    - This will trigger the 'release' github action which will upload to PyPi.


### PR DESCRIPTION
This adds a github action to trigger a release to pypi when a tag is pushed. I have not released anything to pypi before so the workflow may not be optimal. I have tested it with `test.pypi.org` and it seems to be working.

To complete the setup I think the following things have to be configured:
- in pypi, configure a 'Trusted Publisher' from this repo to the project `maturin-import-hook`
- create an environment in the repo called `release`
- add branch protection to `main` if it is not already in place

I took inspiration from the maturin release workflow as well. Of course that is more complex because it requires compilation for different platforms. I'm not sure if we want to do github/signed releases or whether uploading to pypi is sufficient.