### PR TITLE
Upgrade maturin

### DIFF
--- a/src/maturin_import_hook/settings.py
+++ b/src/maturin_import_hook/settings.py
@@ -121,6 +121,7 @@ class MaturinDevelopSettings(MaturinSettings):
     """settings for `maturin develop`."""
 
     extras: Optional[list[str]] = None
+    uv: bool = False
     skip_install: bool = False
 
     @staticmethod
@@ -132,6 +133,8 @@ class MaturinDevelopSettings(MaturinSettings):
         if self.extras is not None:
             args.append("--extras")
             args.append(",".join(self.extras))
+        if self.uv:
+            args.append("--uv")
         if self.skip_install:
             args.append("--skip-install")
         args.extend(super().to_args())

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,8 @@ To update maturin:
 - update the submodule to the maturin commit you want to update to
 - re-run the `package_resolver` to update `resolved.json` (see `package_resolver/README.md` for instructions)
 - update `requirements.txt` to match the packages and versions used by the maturin ci (`.github/workflows.test.yml`)
+    - check the `uniffi` package version listed in the `Cargo.toml` of any of the `uniffi-*`
+      test crates and update `uniffi-bindgen` in `requirements.txt` to match.
 - check that no crates have been added to `test-crates` that should be excluded from the import hook tests.
   If so, add them to `IGNORED_TEST_CRATES` in `common.py`
 - update the version check in the import hook to ensure it allows using the new version

--- a/tests/package_resolver/Cargo.lock
+++ b/tests/package_resolver/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-config2"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3108787cb889089c29b110a3a7165c7c942f081c91d46c477818c33202b2a9cb"
+checksum = "d83ce0be8bd1479e5de6202def660e6c7e27e4e0599bffa4fed05bd380ec2ede"
 dependencies = [
  "home",
  "serde",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-options"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad71bf996c8e5b9d28ef3472d7ee41f277edf4e38cd597f51ad0438d05d76ea"
+checksum = "f3540247c0a37a76eb324acc238dc617786ea22c43b95da560c82a8f2714321f"
 dependencies = [
  "anstyle",
  "clap",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb76e6ab558f9138291c7e1fa954ffd58e060712eab13f97a317da712218ca24"
+checksum = "65004153e67ac23be88a8e244304a872d727b2aa08654dcabfbecd1fdea4a488"
 dependencies = [
  "anyhow",
  "cargo-options",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
 -e ..
 uv
-maturin==1.5.0
+maturin==1.6.0
 pytest
 junit2html
-uniffi-bindgen==0.26.0
+uniffi-bindgen==0.27.0
 cffi
 
 # required for pyo3-mixed

--- a/tests/resolved.json
+++ b/tests/resolved.json
@@ -1,5 +1,5 @@
 {
-  "commit": "7d711f0c4a7c052608dc2e16d5c6721b9666d076",
+  "commit": "894231c644c2d7a9a31349c86b3f3c431b74d615",
   "crates": {
     "cffi-mixed": {
       "cargo_manifest_path": "Cargo.toml",

--- a/tests/test_import_hook/file_importer_helpers/my_script_1.rs
+++ b/tests/test_import_hook/file_importer_helpers/my_script_1.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 fn get_num() -> usize { 10 }
 
 #[pymodule]
-fn my_script(_py: Python, m: &PyModule) -> PyResult<()> {
+fn my_script(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_num))?;
     Ok(())
 }

--- a/tests/test_import_hook/file_importer_helpers/my_script_2.rs
+++ b/tests/test_import_hook/file_importer_helpers/my_script_2.rs
@@ -7,7 +7,7 @@ fn get_num() -> usize { 20 }
 fn get_other_num() -> usize { 100 }
 
 #[pymodule]
-fn my_script(_py: Python, m: &PyModule) -> PyResult<()> {
+fn my_script(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_num))?;
     m.add_wrapped(wrap_pyfunction!(get_other_num))?;
     Ok(())

--- a/tests/test_import_hook/file_importer_helpers/my_script_3.rs
+++ b/tests/test_import_hook/file_importer_helpers/my_script_3.rs
@@ -10,7 +10,7 @@ fn get_num() -> usize {
 }
 
 #[pymodule]
-fn my_script(_py: Python, m: &PyModule) -> PyResult<()> {
+fn my_script(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_num))?;
     Ok(())
 }

--- a/tests/test_import_hook/file_importer_helpers/packages/my_rust_module.rs
+++ b/tests/test_import_hook/file_importer_helpers/packages/my_rust_module.rs
@@ -1,5 +1,4 @@
 use pyo3::prelude::*;
-use pyo3::wrap_pyfunction;
 
 #[pyfunction]
 pub fn do_something(a: usize, b: usize) -> PyResult<usize> {
@@ -7,7 +6,7 @@ pub fn do_something(a: usize, b: usize) -> PyResult<usize> {
 }
 
 #[pymodule]
-pub fn my_rust_module(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn my_rust_module(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(do_something))?;
     Ok(())
 }

--- a/tests/test_import_hook/file_importer_helpers/reload_template.rs
+++ b/tests/test_import_hook/file_importer_helpers/reload_template.rs
@@ -40,7 +40,7 @@ impl Integer {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<bool> {
-        let logging = PyModule::import(py, "logging")?;
+        let logging = PyModule::import_bound(py, "logging")?;
         let message = format!(
             "comparing Integer instances {} and {}",
             self.name, other.name
@@ -66,7 +66,7 @@ impl PicklableInteger {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<bool> {
-        let logging = PyModule::import(py, "logging")?;
+        let logging = PyModule::import_bound(py, "logging")?;
         let message = format!(
             "comparing PicklableInteger instances {} and {}",
             self.name, other.name
@@ -88,15 +88,15 @@ fn get_str() -> String {
     string
 }
 
-fn register_child_module(py: Python<'_>, parent_module: &PyModule) -> PyResult<()> {
-    let child_module = PyModule::new(py, "child")?;
+fn register_child_module(py: Python<'_>, parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let child_module = PyModule::new_bound(py, "child")?;
     child_module.add_wrapped(wrap_pyfunction!(get_str))?;
-    parent_module.add_submodule(child_module)?;
+    parent_module.add_submodule(&child_module)?;
     Ok(())
 }
 
 #[pymodule]
-fn my_module(py: Python, m: &PyModule) -> PyResult<()> {
+fn my_module(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_num))?;
     m.add_wrapped(wrap_pyfunction!(get_global_num))?;
     m.add_wrapped(wrap_pyfunction!(set_global_num))?;
@@ -105,19 +105,19 @@ fn my_module(py: Python, m: &PyModule) -> PyResult<()> {
 
     register_child_module(py, m)?;
 
-    let data = PyDict::new(py);
+    let data = PyDict::new_bound(py);
     data.set_item("foo", 123)?;
     m.add("data", data)?;
 
     if !m.hasattr("data_init_once")? {
-        let data = PyDict::new(py);
+        let data = PyDict::new_bound(py);
         data.set_item("foo", 123)?;
         m.add("data_init_once", data)?;
     }
 
     m.add("data_str", "foo")?;
 
-    let logging = PyModule::import(py, "logging")?;
+    let logging = PyModule::import_bound(py, "logging")?;
     logging
         .getattr("info")?
         .call1(("my_module extension module initialised",))?;

--- a/tests/test_import_hook/project_importer_helpers/blank-project/Cargo.lock
+++ b/tests/test_import_hook/project_importer_helpers/blank-project/Cargo.lock
@@ -94,6 +94,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,15 +110,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
  "parking_lot",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -121,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -131,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -141,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -153,12 +160,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/tests/test_import_hook/project_importer_helpers/blank-project/Cargo.toml
+++ b/tests/test_import_hook/project_importer_helpers/blank-project/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = ""
 
 [dependencies]
-pyo3 = { version = "0.20.2", features = ["extension-module"] }
+pyo3 = { version = "0.21.2", features = ["extension-module"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/test_import_hook/project_importer_helpers/blank-project/src/lib.rs
+++ b/tests/test_import_hook/project_importer_helpers/blank-project/src/lib.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 
 #[pymodule]
-fn blank_project(_py: Python, _m: &PyModule) -> PyResult<()> {
+fn blank_project(_m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }

--- a/tests/test_import_hook/project_importer_helpers/my_project.rs
+++ b/tests/test_import_hook/project_importer_helpers/my_project.rs
@@ -11,7 +11,7 @@ fn get_num() -> usize {
 }
 
 #[pymodule]
-fn my_project(_py: Python, m: &PyModule) -> PyResult<()> {
+fn my_project(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_num))?;
     Ok(())
 }

--- a/tests/test_import_hook/project_importer_helpers/reload_template.rs
+++ b/tests/test_import_hook/project_importer_helpers/reload_template.rs
@@ -40,7 +40,7 @@ impl Integer {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<bool> {
-        let logging = PyModule::import(py, "logging")?;
+        let logging = PyModule::import_bound(py, "logging")?;
         let message = format!(
             "comparing Integer instances {} and {}",
             self.name, other.name
@@ -66,7 +66,7 @@ impl PicklableInteger {
     }
 
     fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<bool> {
-        let logging = PyModule::import(py, "logging")?;
+        let logging = PyModule::import_bound(py, "logging")?;
         let message = format!(
             "comparing PicklableInteger instances {} and {}",
             self.name, other.name
@@ -88,15 +88,15 @@ fn get_str() -> String {
     string
 }
 
-fn register_child_module(py: Python<'_>, parent_module: &PyModule) -> PyResult<()> {
-    let child_module = PyModule::new(py, "child")?;
+fn register_child_module(py: Python<'_>, parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let child_module = PyModule::new_bound(py, "child")?;
     child_module.add_wrapped(wrap_pyfunction!(get_str))?;
-    parent_module.add_submodule(child_module)?;
+    parent_module.add_submodule(&child_module)?;
     Ok(())
 }
 
 #[pymodule]
-fn my_project(py: Python, m: &PyModule) -> PyResult<()> {
+fn my_project(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(get_num))?;
     m.add_wrapped(wrap_pyfunction!(get_global_num))?;
     m.add_wrapped(wrap_pyfunction!(set_global_num))?;
@@ -105,19 +105,19 @@ fn my_project(py: Python, m: &PyModule) -> PyResult<()> {
 
     register_child_module(py, m)?;
 
-    let data = PyDict::new(py);
+    let data = PyDict::new_bound(py);
     data.set_item("foo", 123)?;
     m.add("data", data)?;
 
     if !m.hasattr("data_init_once")? {
-        let data = PyDict::new(py);
+        let data = PyDict::new_bound(py);
         data.set_item("foo", 123)?;
         m.add("data_init_once", data)?;
     }
 
     m.add("data_str", "foo")?;
 
-    let logging = PyModule::import(py, "logging")?;
+    let logging = PyModule::import_bound(py, "logging")?;
     logging
         .getattr("info")?
         .call1(("my_project extension module initialised",))?;

--- a/tests/test_import_hook/test_project_importer.py
+++ b/tests/test_import_hook/test_project_importer.py
@@ -1395,7 +1395,7 @@ def _install_editable(project_dir: Path) -> None:
     assert maturin_path is not None
     env = os.environ.copy()
     env["VIRTUAL_ENV"] = sys.exec_prefix
-    subprocess.check_call([maturin_path, "develop"], cwd=project_dir, env=env)
+    subprocess.check_call([maturin_path, "develop", "--uv"], cwd=project_dir, env=env)
 
 
 def _install_non_editable(project_dir: Path) -> None:

--- a/tests/test_import_hook/test_utilities.py
+++ b/tests/test_import_hook/test_utilities.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import os
 import platform
 import re
 import subprocess
@@ -30,12 +31,13 @@ log = logging.getLogger(__name__)
 
 def test_maturin_unchanged() -> None:
     """if new options have been added to maturin then the import hook needs to be updated to match"""
+    env = {"PATH": os.environ["PATH"], "COLUMNS": "120"}
 
-    build_help = subprocess.check_output(["maturin", "build", "--help"])
-    assert hashlib.sha1(build_help).hexdigest() == "f3ea5264a77e621d3e7e31afd80d96b51cc74154"
+    build_help = subprocess.check_output("stty rows 50 cols 120; maturin build --help", shell=True, env=env)  # noqa: S602
+    assert hashlib.sha1(build_help).hexdigest() == "99f80713607f23c53a0a936c36789c7c4186d5a9"
 
-    develop_help = subprocess.check_output(["maturin", "develop", "--help"])
-    assert hashlib.sha1(develop_help).hexdigest() == "30aed063dbaf2816ac474fa0aebb444bf326aa6b"
+    develop_help = subprocess.check_output("stty rows 50 cols 120; maturin develop --help", shell=True, env=env)  # noqa: S602
+    assert hashlib.sha1(develop_help).hexdigest() == "ad7036a829c6801224933d589b1f9848678c9458"
 
 
 def test_settings() -> None:


### PR DESCRIPTION
(the tests fail because they still rely on virtualenv which was removed in #5. I will rebase once #5 is merged)

Update to maturin 1.6.0 and make the associated changes
- use bind API for PyO3 code
- update dependencies, eg uniffi
- add support for `--uv` option
- fixed an issue where `maturin build --help` and `maturin develop --help` were word wrapping at a different number of columns. It seems that using `stty` and the `COLUMNS` environment variable is required to use the same width in all situations