### PR TITLE
Add cache for _find_maturin_project_above

### DIFF
--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import importlib
 import importlib.abc
 import importlib.machinery
@@ -373,6 +374,7 @@ def _is_editable_installed_package(project_dir: Path, package_name: str) -> bool
     return False
 
 
+@functools.lru_cache(maxsize=None) # number of serach paths should be small
 def _find_maturin_project_above(path: Path) -> Optional[Path]:
     for search_path in itertools.chain((path,), path.parents):
         if is_maybe_maturin_project(search_path):

--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -374,7 +374,7 @@ def _is_editable_installed_package(project_dir: Path, package_name: str) -> bool
     return False
 
 
-@functools.lru_cache(maxsize=None) # number of serach paths should be small
+@functools.cache
 def _find_maturin_project_above(path: Path) -> Optional[Path]:
     for search_path in itertools.chain((path,), path.parents):
         if is_maybe_maturin_project(search_path):


### PR DESCRIPTION
I noticed my app's launch to take *forever* (nearly half a minute) with most of time spent in `_find_maturin_project_above` which is called repeatedly for every search path whenever a module is loaded.

Adding a cache ensures that search paths aren't analyzed over and over again.

AFAIK using `functools.cache` (added in 3.9) should be okay as this project requires Python 3.9. If compatibility is a concern, one could use `functools.lru_cache(maxsize=None)` instead.