### PR TITLE
add ignore marker file to default project searcher

### DIFF
--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -484,9 +484,11 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
     }
     DEFAULT_SOURCE_EXCLUDED_DIR_MARKERS: ClassVar[set[str]] = {
         "CACHEDIR.TAG",  # https://bford.info/cachedir/
+        ".maturin_hook_ignore",
     }
     DEFAULT_SOURCE_EXCLUDED_FILE_EXTENSIONS: ClassVar[set[str]] = {
         ".so",
+        ".py",
         ".pyc",
     }
 


### PR DESCRIPTION
Currently, the `DefaultProjectFileSearcher` is very conservative, but I think some changes it might provide a better experience for the majority of users.

I ran into a case where I had a package with a `tests/` directory (containing only .py files) and I realised there was no built-in way to ignore this directory other than passing a custom `ProjectFileSearcher` to `install()` which is not ideal when working in a team.

With this change, a `.maturin_hook_ignore` file could be added to `tests/` to have that directory ignored.

Additionally, I don't think there are many use cases for depending on .py files for the compiled part of a package, but it is very common to have .py files in the repository of a maturin package that do not need to trigger a rebuild.
If a package depends on .py files at compile time with `include_str!()` or similar then a custom `ProjectFileSearcher` can be passed, or the following can be put before calling `install()`:
```python
maturin_import_hook.project_importer.DefaultProjectFileSearcher.DEFAULT_SOURCE_EXCLUDED_FILE_EXTENSIONS.discard('.py')
```