### PR TITLE
Customize install

### DIFF
--- a/src/maturin_import_hook/_building.py
+++ b/src/maturin_import_hook/_building.py
@@ -149,9 +149,6 @@ def build_wheel(
     output_dir: Path,
     settings: MaturinSettings,
 ) -> str:
-    if "build" not in settings.supported_commands():
-        msg = f'provided {type(settings).__name__} does not support the "build" command'
-        raise ImportHookError(msg)
     success, output = run_maturin(
         maturin_path,
         [
@@ -162,7 +159,7 @@ def build_wheel(
             sys.executable,
             "--out",
             str(output_dir),
-            *settings.to_args(),
+            *settings.to_args("build"),
         ],
     )
     if not success:
@@ -176,10 +173,9 @@ def develop_build_project(
     manifest_path: Path,
     settings: MaturinSettings,
 ) -> str:
-    if "develop" not in settings.supported_commands():
-        msg = f'provided {type(settings).__name__} does not support the "develop" command'
-        raise ImportHookError(msg)
-    success, output = run_maturin(maturin_path, ["develop", "--manifest-path", str(manifest_path), *settings.to_args()])
+    success, output = run_maturin(
+        maturin_path, ["develop", "--manifest-path", str(manifest_path), *settings.to_args("develop")]
+    )
     if not success:
         msg = "Failed to build package with maturin"
         raise MaturinError(msg)

--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -281,7 +281,7 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
                 if mtime is None:
                     logger.error("could not get installed package mtime")
                 else:
-                    build_status = BuildStatus(mtime, project_dir, settings.to_args(), maturin_output)
+                    build_status = BuildStatus(mtime, project_dir, settings.to_args("develop"), maturin_output)
                     build_cache.store_build_status(build_status)
 
         return spec, True
@@ -315,7 +315,7 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
             return None, "no build status found"
         if build_status.source_path != project_dir:
             return None, "source path in build status does not match the project dir"
-        if build_status.maturin_args != settings.to_args():
+        if build_status.maturin_args != settings.to_args("develop"):
             return None, "current maturin args do not match the previous build"
 
         installed_paths = self._file_searcher.get_installation_paths(installed_package_root)

--- a/src/maturin_import_hook/rust_file_importer.py
+++ b/src/maturin_import_hook/rust_file_importer.py
@@ -236,7 +236,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
             build_status = BuildStatus(
                 extension_module_path.stat().st_mtime,
                 file_path,
-                settings.to_args(),
+                settings.to_args("build"),
                 maturin_output,
             )
             build_cache.store_build_status(build_status)
@@ -270,7 +270,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
             return None, "no build status found"
         if build_status.source_path != source_path:
             return None, "source path in build status does not match the project dir"
-        if build_status.maturin_args != settings.to_args():
+        if build_status.maturin_args != settings.to_args("build"):
             return None, "current maturin args do not match the previous build"
 
         freshness = get_installation_freshness(

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vv


### PR DESCRIPTION
- Replaces the limited `site install --preset` options with full parsing of `maturin` commands
-  automatic detection of when `--uv` is required (`site install --no-detect-uv` to disable).
- automatic `--color always` when not specified
- enable/disable project or rs file importer with `--project-importer/--no-project-importer` and `--rs-file-importer/--no-rs-file-importer`

eg:
```sh
python -m maturin_import_hook site install \
    --force --no-rs-file-importer --args="--release --uv --features feature1,feature2 -- --cfg foo"
```
writes the following:
```python
...
    maturin_import_hook.install(
        settings=MaturinSettings(
            release=True,
            features=['feature1', 'feature2'],
            color=True,
            rustc_flags=['--cfg', 'foo'],
            uv=True
        ),
        enable_project_importer=True,
        enable_rs_file_importer=False,
    )
```

the `MaturinDevelopSettings` and `MaturinBuildSettings` are merged with `MaturinSettings` as inheritance was not really the correct tool. With the inheritance approach it was impossible to set both `maturin build` and `maturin develop` settings simultaneously.