### PR TITLE
better error handling for managed site installations

### DIFF
--- a/src/maturin_import_hook/__main__.py
+++ b/src/maturin_import_hook/__main__.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+from maturin_import_hook import project_importer, rust_file_importer
 from maturin_import_hook._building import get_default_build_dir
 from maturin_import_hook._site import (
     get_sitecustomize_path,
@@ -94,6 +95,8 @@ def _action_site_info(format_name: str) -> None:
             "usercustomize_path": str(usercustomize_path),
             "usercustomize_exists": usercustomize_path.exists(),
             "usercustomize_import_hook_installed": has_automatic_installation(usercustomize_path),
+            "project_importer_installed": project_importer.is_installed(),
+            "rust_file_importer_installed": rust_file_importer.is_installed(),
         },
         format_name,
     )
@@ -108,8 +111,21 @@ def _action_site_install(
     enable_rs_file_importer: bool,
     detect_uv: bool,
 ) -> None:
-    module_path = get_usercustomize_path() if user else get_sitecustomize_path()
-    insert_automatic_installation(module_path, force, args, enable_project_importer, enable_rs_file_importer, detect_uv)
+    if user:
+        module_path = get_usercustomize_path()
+        uninstall_command = "python -m maturin_import_hook site uninstall --user"
+    else:
+        module_path = get_sitecustomize_path()
+        uninstall_command = "python -m maturin_import_hook site uninstall"
+    insert_automatic_installation(
+        module_path,
+        uninstall_command,
+        force,
+        args,
+        enable_project_importer,
+        enable_rs_file_importer,
+        detect_uv,
+    )
 
 
 def _action_site_uninstall(*, user: bool) -> None:

--- a/tests/test_import_hook/test_site.py
+++ b/tests/test_import_hook/test_site.py
@@ -26,6 +26,7 @@ def test_automatic_site_installation(tmp_path: Path) -> None:
 
     insert_automatic_installation(
         sitecustomize,
+        "<uninstall>",
         force=False,
         args=None,
         enable_project_importer=True,
@@ -36,6 +37,7 @@ def test_automatic_site_installation(tmp_path: Path) -> None:
     with capture_logs() as cap:
         insert_automatic_installation(
             sitecustomize,
+            "<uninstall>",
             force=False,
             args=None,
             enable_project_importer=True,
@@ -56,15 +58,17 @@ def test_automatic_site_installation(tmp_path: Path) -> None:
     try:
         import maturin_import_hook
         from maturin_import_hook.settings import MaturinSettings
-    except ImportError:
-        pass
-    else:
         maturin_import_hook.install(
             settings=MaturinSettings(
                 color=True
             ),
             enable_project_importer=True,
             enable_rs_file_importer=True,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"{e}\\n>> ERROR in managed maturin_import_hook installation. "
+            "Remove with `<uninstall>`\\n",
         )
     # </maturin_import_hook>
     """)
@@ -107,6 +111,7 @@ def test_automatic_site_installation_force_overwrite(tmp_path: Path) -> None:
 
     insert_automatic_installation(
         sitecustomize,
+        "<uninstall>",
         force=False,
         args=None,
         enable_project_importer=True,
@@ -119,6 +124,7 @@ def test_automatic_site_installation_force_overwrite(tmp_path: Path) -> None:
     with capture_logs() as cap:
         insert_automatic_installation(
             sitecustomize,
+            "<uninstall>",
             force=True,
             args="--release",
             enable_project_importer=True,
@@ -142,9 +148,6 @@ def test_automatic_site_installation_force_overwrite(tmp_path: Path) -> None:
     try:
         import maturin_import_hook
         from maturin_import_hook.settings import MaturinSettings
-    except ImportError:
-        pass
-    else:
         maturin_import_hook.install(
             settings=MaturinSettings(
                 release=True,
@@ -152,6 +155,11 @@ def test_automatic_site_installation_force_overwrite(tmp_path: Path) -> None:
             ),
             enable_project_importer=True,
             enable_rs_file_importer=True,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"{e}\\n>> ERROR in managed maturin_import_hook installation. "
+            "Remove with `<uninstall>`\\n",
         )
     # </maturin_import_hook>
     """)
@@ -165,6 +173,7 @@ def test_automatic_site_installation_invalid_args(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="argument parser error"):
         insert_automatic_installation(
             sitecustomize,
+            "<uninstall>",
             force=False,
             args="--foo",
             enable_project_importer=True,
@@ -178,6 +187,7 @@ def test_automatic_site_installation_empty(tmp_path: Path) -> None:
     sitecustomize = tmp_path / "sitecustomize.py"
     insert_automatic_installation(
         sitecustomize,
+        "<uninstall>",
         force=False,
         args=None,
         enable_project_importer=True,
@@ -192,15 +202,17 @@ def test_automatic_site_installation_empty(tmp_path: Path) -> None:
     try:
         import maturin_import_hook
         from maturin_import_hook.settings import MaturinSettings
-    except ImportError:
-        pass
-    else:
         maturin_import_hook.install(
             settings=MaturinSettings(
                 color=True
             ),
             enable_project_importer=True,
             enable_rs_file_importer=True,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"{e}\\n>> ERROR in managed maturin_import_hook installation. "
+            "Remove with `<uninstall>`\\n",
         )
     # </maturin_import_hook>
     """)


### PR DESCRIPTION
With `MaturinBuildSettings` and `MaturinDevelopSettings` removed in https://github.com/PyO3/maturin-import-hook/pull/11 I was concerned about what would happen if users are importing these classes in `sitecustomize.py`. Looking at the `0.1.0` release, the `presets` option wasn't available so it's unlikely many user's installs will break.


It seems that when something breaks in `sitecustomize.py` an error is printed but the interpreter continues. To help the user resolve the problem, managed installations now print a message informing the user how they can remove the installation to resolve the error:
```
$ python
Error in sitecustomize; set PYTHONVERBOSE for traceback:
RuntimeError: MaturinSettings.__init__() got an unexpected keyword argument 'asdf'
>> ERROR in managed maturin_import_hook installation. Remove with `python -m maturin_import_hook site uninstall`

Python 3.13.1 (main, Dec  6 2024, 18:40:43) [Clang 18.1.8 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```

In future, if any maturin flags change and `MaturinSettings` changes to match, breakages could become more common so it is important to handle this case properly.