### PR TITLE
Fix excluded dir marker check

### DIFF
--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -593,7 +593,7 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
 
         for dir_str, dirs, files in os.walk(root_path, topdown=True):
             dir_path = Path(dir_str)
-            include_dir = dir_path not in ignore_dirs and not any(dir_name in excluded_dir_markers for dir_name in dirs)
+            include_dir = dir_path not in ignore_dirs and not any(name in excluded_dir_markers for name in files)
 
             if include_dir:
                 dirs[:] = sorted(dir_name for dir_name in dirs if dir_name not in excluded_dir_names)


### PR DESCRIPTION
When checking for markers that exclude the directory that contains them, the hook erroneously expected these markers to be directories instead of files. This breaks with the CACHEDIR.TAG spec, which explicitly states:

> This file *must* be an ordinary file, not for example a symbolic link.