### PR TITLE
upgrade python and linters (PR 1/3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ on:
         options:
         - 'all'
         - '3.11'
-        - '3.14t'
-        - '3.14'
+        - '3.13t'
+        - '3.13'
         - 'pypy3.11'
       test_specification:
         type: string
@@ -57,8 +57,8 @@ jobs:
         - windows-latest
       PYTHON_VERSION: |
         - '3.11'
-        - '3.14t'
-        - '3.14'
+        - '3.13t'
+        - '3.13'
         - 'pypy3.11'
     steps:
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,10 @@ on:
         default: '3.13'
         options:
         - 'all'
-        - '3.9'
-        - '3.13t'
-        - '3.13'
-        - 'pypy3.9'
-        - 'pypy3.10'
+        - '3.11'
+        - '3.14t'
+        - '3.14'
+        - 'pypy3.11'
       test_specification:
         type: string
         description: Specification for the tests to run
@@ -57,11 +56,10 @@ jobs:
         - macos-14
         - windows-latest
       PYTHON_VERSION: |
-        - '3.9'
-        - '3.13t'
-        - '3.13'
-        - 'pypy3.9'
-        - 'pypy3.10'
+        - '3.11'
+        - '3.14t'
+        - '3.14'
+        - 'pypy3.11'
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-toml
@@ -8,13 +8,13 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.15.21
     hooks:
       - id: ruff-format
       - id: ruff
         args: [ --fix ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v2.2.0
     hooks:
       # note: mypy runs in an isolated environment and so has no access to third party packages
       - id: mypy
@@ -22,10 +22,10 @@ repos:
         pass_filenames: false
         additional_dependencies: ["pytest"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     - id: codespell
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.49.0
     hooks:
     - id: markdownlint-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,9 @@ authors = [
 ]
 readme = "README.md"
 version = "0.3.0"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "filelock",
-    "tomli>=1.1.0 ; python_version<'3.11'"
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -28,12 +27,17 @@ Repository = "https://github.com/PyO3/maturin-import-hook.git"
 Issues = "https://github.com/PyO3/maturin-import-hook/issues"
 Changelog = "https://github.com/PyO3/maturin-import-hook/blob/main/Changelog.md"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.format]
 preview = true
@@ -69,7 +73,7 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 strict = true
 allow_redefinition = true
 exclude = [

--- a/src/maturin_import_hook/__init__.py
+++ b/src/maturin_import_hook/__init__.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Optional
 
 from maturin_import_hook import project_importer, rust_file_importer
 from maturin_import_hook._logging import logger, reset_logger
@@ -14,12 +13,12 @@ def install(
     enable_project_importer: bool = True,
     enable_rs_file_importer: bool = True,
     enable_reloading: bool = True,
-    settings: Optional[MaturinSettings] = None,
-    build_dir: Optional[Path] = None,
+    settings: MaturinSettings | None = None,
+    build_dir: Path | None = None,
     force_rebuild: bool = False,
-    lock_timeout_seconds: Optional[float] = 120,
+    lock_timeout_seconds: float | None = 120,
     show_warnings: bool = True,
-    file_searcher: Optional[project_importer.ProjectFileSearcher] = None,
+    file_searcher: project_importer.ProjectFileSearcher | None = None,
     enable_automatic_installation: bool = False,
 ) -> None:
     """Install import hooks for automatically rebuilding and importing maturin projects or .rs files.

--- a/src/maturin_import_hook/__main__.py
+++ b/src/maturin_import_hook/__main__.py
@@ -6,7 +6,6 @@ import shutil
 import site
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 from maturin_import_hook import project_importer, rust_file_importer
 from maturin_import_hook._building import get_default_build_dir
@@ -106,7 +105,7 @@ def _action_site_install(
     *,
     user: bool,
     force: bool,
-    args: Optional[str],
+    args: str | None,
     enable_project_importer: bool,
     enable_rs_file_importer: bool,
 ) -> None:

--- a/src/maturin_import_hook/_building.py
+++ b/src/maturin_import_hook/_building.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import json
 import logging
@@ -8,18 +10,21 @@ import shutil
 import subprocess
 import sys
 import zipfile
-from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from operator import itemgetter
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import filelock
 
 from maturin_import_hook._logging import logger
 from maturin_import_hook.error import ImportHookError, MaturinError
-from maturin_import_hook.settings import MaturinSettings
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
+    from maturin_import_hook.settings import MaturinSettings
 
 
 @dataclass
@@ -43,7 +48,7 @@ class BuildStatus:
         }
 
     @staticmethod
-    def from_json(json_data: dict[Any, Any]) -> Optional["BuildStatus"]:
+    def from_json(json_data: dict[Any, Any]) -> BuildStatus | None:
         try:
             return BuildStatus(
                 build_mtime=json_data["build_mtime"],
@@ -70,7 +75,7 @@ class LockedBuildCache:
         with self._build_status_path(build_status.source_path).open("w") as f:
             json.dump(build_status.to_json(), f, indent="  ")
 
-    def get_build_status(self, source_path: Path) -> Optional[BuildStatus]:
+    def get_build_status(self, source_path: Path) -> BuildStatus | None:
         try:
             with self._build_status_path(source_path).open("r") as f:
                 return BuildStatus.from_json(json.load(f))
@@ -83,7 +88,7 @@ class LockedBuildCache:
 
 
 class BuildCache:
-    def __init__(self, build_dir: Optional[Path], lock_timeout_seconds: Optional[float]) -> None:
+    def __init__(self, build_dir: Path | None, lock_timeout_seconds: float | None) -> None:
         self._build_dir = build_dir if build_dir is not None else get_default_build_dir()
         self._lock = filelock.FileLock(
             self._build_dir / "lock", timeout=-1 if lock_timeout_seconds is None else lock_timeout_seconds
@@ -96,7 +101,7 @@ class BuildCache:
 
 
 @contextmanager
-def _acquire_lock(lock: filelock.FileLock) -> Generator[None, None, None]:
+def _acquire_lock(lock: filelock.BaseFileLock) -> Generator[None, None, None]:
     try:
         try:
             with lock.acquire(blocking=False):
@@ -245,7 +250,7 @@ def build_unpacked_wheel(maturin_path: Path, manifest_path: Path, output_dir: Pa
     return output
 
 
-def _find_single_file(dir_path: Path, extension: Optional[str]) -> Optional[Path]:
+def _find_single_file(dir_path: Path, extension: str | None) -> Path | None:
     if dir_path.exists():
         candidate_files = [p for p in dir_path.iterdir() if extension is None or p.suffix == extension]
     else:
@@ -261,8 +266,8 @@ def maturin_output_has_warnings(output: str) -> bool:
 class Freshness:
     is_fresh: bool
     reason: str
-    oldest_installed_path: Optional[Path]
-    newest_source_path: Optional[Path]
+    oldest_installed_path: Path | None
+    newest_source_path: Path | None
 
 
 def get_installation_freshness(
@@ -326,7 +331,7 @@ def get_installation_freshness(
         return Freshness(True, "", oldest_installed_path, newest_source_path)
 
 
-def get_installation_mtime(installed_paths: Iterable[Path]) -> Optional[float]:
+def get_installation_mtime(installed_paths: Iterable[Path]) -> float | None:
     try:
         installation_mtime = min(path.stat().st_mtime for path in installed_paths)
     except ValueError:

--- a/src/maturin_import_hook/_common.py
+++ b/src/maturin_import_hook/_common.py
@@ -2,7 +2,6 @@ import atexit
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional
 
 from maturin_import_hook._logging import logger
 
@@ -12,7 +11,7 @@ class LazySessionTemporaryDirectory:
 
     def __init__(self, *, prefix: str) -> None:
         self._prefix = prefix
-        self._tmp_path: Optional[Path] = None
+        self._tmp_path: Path | None = None
 
     def __del__(self) -> None:
         self._cleanup()

--- a/src/maturin_import_hook/_resolve_project.py
+++ b/src/maturin_import_hook/_resolve_project.py
@@ -1,15 +1,10 @@
 import itertools
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, TypeVar
 
 from maturin_import_hook._logging import logger
-
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
-
 
 _T = TypeVar("_T")
 
@@ -33,7 +28,7 @@ class _TomlFile:
         value = self.get_value(keys, required_type)
         return default if value is None else value
 
-    def get_value(self, keys: list[str], required_type: type[_T]) -> Optional[_T]:
+    def get_value(self, keys: list[str], required_type: type[_T]) -> _T | None:
         assert keys
         current_data: Any = self.data
         num_keys = len(keys)
@@ -58,7 +53,7 @@ class _TomlFile:
             return current_data
 
 
-def find_cargo_manifest(project_dir: Path) -> Optional[Path]:
+def find_cargo_manifest(project_dir: Path) -> Path | None:
     pyproject_path = project_dir / "pyproject.toml"
     if pyproject_path.is_file():
         pyproject_data = pyproject_path.read_text()
@@ -88,7 +83,7 @@ def is_maybe_maturin_project(directory: Path) -> bool:
 
 class ProjectResolver:
     def __init__(self) -> None:
-        self._resolved_project_cache: dict[Path, Optional[MaturinProject]] = {}
+        self._resolved_project_cache: dict[Path, MaturinProject | None] = {}
 
     def clear_cache(self) -> None:
         self._resolved_project_cache.clear()
@@ -115,13 +110,13 @@ class MaturinProject:
     # the root of the python part of the project (or the project root if there is none)
     python_dir: Path
     # the path to the top level python package if the project is mixed
-    python_module: Optional[Path]
+    python_module: Path | None
     # the location that the compiled extension module is written to when installed in editable/unpacked mode
-    extension_module_dir: Optional[Path]
+    extension_module_dir: Path | None
     # path dependencies listed in the Cargo.toml of the main project
     immediate_path_dependencies: list[Path]
     # all path dependencies including transitive dependencies
-    _all_path_dependencies: Optional[list[Path]] = None
+    _all_path_dependencies: list[Path] | None = None
 
     @property
     def package_name(self) -> str:
@@ -204,8 +199,8 @@ def _resolve_project(project_dir: Path) -> MaturinProject:
 
     python_dir = _resolve_py_root(project_dir, pyproject)
 
-    extension_module_dir: Optional[Path]
-    python_module: Optional[Path]
+    extension_module_dir: Path | None
+    python_module: Path | None
     python_module, extension_module_dir, _extension_module_name = _resolve_rust_module(python_dir, module_full_name)
     immediate_path_dependencies = _get_immediate_path_dependencies(manifest_path.parent, cargo)
 
@@ -248,7 +243,7 @@ def _resolve_rust_module(python_dir: Path, module_name: str) -> tuple[Path, Path
     return python_module, extension_module_dir, extension_module_name
 
 
-def _resolve_module_name(pyproject: _TomlFile, cargo: _TomlFile) -> Optional[str]:
+def _resolve_module_name(pyproject: _TomlFile, cargo: _TomlFile) -> str | None:
     """This follows the same logic as project_layout.rs (ProjectResolver::resolve).
 
     Precedence:

--- a/src/maturin_import_hook/_site.py
+++ b/src/maturin_import_hook/_site.py
@@ -2,7 +2,6 @@ import dataclasses
 import shlex
 import site
 from pathlib import Path
-from typing import Optional
 
 from maturin_import_hook._logging import logger
 from maturin_import_hook.settings import MaturinSettings
@@ -85,7 +84,7 @@ def insert_automatic_installation(
     module_path: Path,
     uninstall_command: str,
     force: bool,
-    args: Optional[str],
+    args: str | None,
     enable_project_importer: bool,
     enable_rs_file_importer: bool,
 ) -> None:

--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -18,7 +18,7 @@ from functools import lru_cache
 from importlib.machinery import ExtensionFileLoader, ModuleSpec, PathFinder
 from pathlib import Path
 from types import ModuleType
-from typing import ClassVar, Optional, Union
+from typing import ClassVar
 
 from maturin_import_hook._building import (
     BuildCache,
@@ -73,10 +73,10 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
     def __init__(
         self,
         *,
-        settings: Optional[MaturinSettings] = None,
-        file_searcher: Optional[ProjectFileSearcher] = None,
-        build_dir: Optional[Path] = None,
-        lock_timeout_seconds: Optional[float] = 120,
+        settings: MaturinSettings | None = None,
+        file_searcher: ProjectFileSearcher | None = None,
+        build_dir: Path | None = None,
+        lock_timeout_seconds: float | None = 120,
         enable_reloading: bool = True,
         enable_automatic_installation: bool = False,
         force_rebuild: bool = False,
@@ -90,7 +90,7 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
         self._enable_automatic_installation = enable_automatic_installation
         self._force_rebuild = force_rebuild
         self._show_warnings = show_warnings
-        self._maturin_path: Optional[Path] = None
+        self._maturin_path: Path | None = None
         self._reload_tmp_path = LazySessionTemporaryDirectory(prefix=type(self).__name__)
 
     def get_settings(self, module_path: str, source_path: Path) -> MaturinSettings:
@@ -112,9 +112,9 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
     def find_spec(
         self,
         fullname: str,
-        path: Optional[Sequence[Union[str, bytes]]] = None,
-        target: Optional[ModuleType] = None,
-    ) -> Optional[ModuleSpec]:
+        path: Sequence[str | bytes] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
         is_top_level_import = path is None
         if not is_top_level_import:
             return None
@@ -221,7 +221,7 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
         self,
         package_name: str,
         project_dir: Path,
-    ) -> tuple[Optional[ModuleSpec], bool]:
+    ) -> tuple[ModuleSpec | None, bool]:
         resolved = self._resolver.resolve(project_dir)
         if resolved is None:
             return None, False
@@ -293,7 +293,7 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
         resolved: MaturinProject,
         settings: MaturinSettings,
         build_cache: LockedBuildCache,
-    ) -> tuple[Optional[ModuleSpec], Optional[str]]:
+    ) -> tuple[ModuleSpec | None, str | None]:
         """Return a spec for the package if it exists and is newer than the source
         code that it is derived from.
         """
@@ -342,7 +342,7 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
             logger.debug(message, prefix, module_path, maturin_output)
 
 
-def _find_spec_for_package(package_name: str) -> Optional[ModuleSpec]:
+def _find_spec_for_package(package_name: str) -> ModuleSpec | None:
     path_finder = PathFinder()
     spec = path_finder.find_spec(package_name)
     if spec is not None:
@@ -383,14 +383,14 @@ def _is_editable_installed_package(project_dir: Path, package_name: str) -> bool
 
 
 @lru_cache(maxsize=4096)
-def _find_maturin_project_above(path: Path) -> Optional[Path]:
+def _find_maturin_project_above(path: Path) -> Path | None:
     for search_path in itertools.chain((path,), path.parents):
         if is_maybe_maturin_project(search_path):
             return search_path
     return None
 
 
-def _find_dist_info_path(directory: Path, package_name: str) -> Optional[Path]:
+def _find_dist_info_path(directory: Path, package_name: str) -> Path | None:
     try:
         names = [item.name for item in directory.iterdir()]
     except (FileNotFoundError, NotADirectoryError):
@@ -401,9 +401,7 @@ def _find_dist_info_path(directory: Path, package_name: str) -> Optional[Path]:
     return None
 
 
-def _load_dist_info(
-    path: Path, package_name: str, *, require_project_target: bool = True
-) -> tuple[Optional[Path], bool]:
+def _load_dist_info(path: Path, package_name: str, *, require_project_target: bool = True) -> tuple[Path | None, bool]:
     dist_info_path = _find_dist_info_path(path, package_name)
     if dist_info_path is None:
         return None, False
@@ -436,7 +434,7 @@ def _uri_to_path(uri: str) -> Path:
     return Path(os.path.normpath(os.path.join(host, path)))  # noqa: PTH118
 
 
-def _find_installed_package_root(resolved: MaturinProject, package_spec: ModuleSpec) -> Optional[Path]:
+def _find_installed_package_root(resolved: MaturinProject, package_spec: ModuleSpec) -> Path | None:
     """Find the root of the files that change each time the project is rebuilt:
     - for mixed projects: the root directory or file of the extension module inside the source tree
     - for pure projects: the root directory of the installed package.
@@ -455,7 +453,7 @@ def _find_installed_package_root(resolved: MaturinProject, package_spec: ModuleS
         return None
 
 
-def _find_extension_module(dir_path: Path, module_name: str, *, require: bool = False) -> Optional[Path]:
+def _find_extension_module(dir_path: Path, module_name: str, *, require: bool = False) -> Path | None:
     if (dir_path / module_name / "__init__.py").exists():
         return dir_path / module_name
 
@@ -517,9 +515,9 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
     def __init__(
         self,
         *,
-        source_excluded_dir_names: Optional[set[str]] = None,
-        source_excluded_dir_markers: Optional[set[str]] = None,
-        source_excluded_file_extensions: Optional[set[str]] = None,
+        source_excluded_dir_names: set[str] | None = None,
+        source_excluded_dir_markers: set[str] | None = None,
+        source_excluded_file_extensions: set[str] | None = None,
     ) -> None:
         """
         Args:
@@ -607,18 +605,18 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
                 dirs.clear()  # do not recurse further into this directory
 
 
-IMPORTER: Optional[MaturinProjectImporter] = None
+IMPORTER: MaturinProjectImporter | None = None
 
 
 def install(
     *,
-    settings: Optional[MaturinSettings] = None,
-    build_dir: Optional[Path] = None,
+    settings: MaturinSettings | None = None,
+    build_dir: Path | None = None,
     enable_reloading: bool = True,
     force_rebuild: bool = False,
-    lock_timeout_seconds: Optional[float] = 120,
+    lock_timeout_seconds: float | None = 120,
     show_warnings: bool = True,
-    file_searcher: Optional[ProjectFileSearcher] = None,
+    file_searcher: ProjectFileSearcher | None = None,
     enable_automatic_installation: bool = False,
 ) -> MaturinProjectImporter:
     """Install an import hook for automatically rebuilding editable installed maturin projects.

--- a/src/maturin_import_hook/rust_file_importer.py
+++ b/src/maturin_import_hook/rust_file_importer.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator, Sequence
 from importlib.machinery import ExtensionFileLoader, ModuleSpec
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from maturin_import_hook._building import (
     BuildCache,
@@ -40,11 +40,11 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
     def __init__(
         self,
         *,
-        settings: Optional[MaturinSettings] = None,
-        build_dir: Optional[Path] = None,
+        settings: MaturinSettings | None = None,
+        build_dir: Path | None = None,
         enable_reloading: bool = True,
         force_rebuild: bool = False,
-        lock_timeout_seconds: Optional[float] = 120,
+        lock_timeout_seconds: float | None = 120,
         show_warnings: bool = True,
     ) -> None:
         self._force_rebuild = force_rebuild
@@ -53,7 +53,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
         self._settings = settings
         self._build_cache = BuildCache(build_dir, lock_timeout_seconds)
         self._show_warnings = show_warnings
-        self._maturin_path: Optional[Path] = None
+        self._maturin_path: Path | None = None
         self._reload_tmp_path = LazySessionTemporaryDirectory(prefix=type(self).__name__)
 
     def get_settings(self, module_path: str, source_path: Path) -> MaturinSettings:
@@ -81,7 +81,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
         if project_dir.exists():
             shutil.rmtree(project_dir)
 
-        success, output = run_maturin(self.find_maturin(), ["new", "--bindings", "pyo3", str(project_dir)])
+        success, _output = run_maturin(self.find_maturin(), ["new", "--bindings", "pyo3", str(project_dir)])
         if not success:
             msg = "Failed to generate project for rust file"
             raise ImportHookError(msg)
@@ -102,9 +102,9 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
     def find_spec(
         self,
         fullname: str,
-        path: Optional[Sequence[Union[str, bytes]]] = None,
-        target: Optional[ModuleType] = None,
-    ) -> Optional[ModuleSpec]:
+        path: Sequence[str | bytes] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
         already_loaded = fullname in sys.modules
         if already_loaded and not self._enable_reloading:
             return self._handle_no_reload(fullname)
@@ -149,7 +149,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
 
         return spec
 
-    def _handle_no_reload(self, module_path: str) -> Optional[ModuleSpec]:
+    def _handle_no_reload(self, module_path: str) -> ModuleSpec | None:
         module = sys.modules[module_path]
         loader = getattr(module, "__loader__", None)
         if isinstance(loader, _RustFileExtensionFileLoader):
@@ -190,9 +190,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
 
         return reloaded_spec
 
-    def _import_rust_file(
-        self, module_path: str, module_name: str, file_path: Path
-    ) -> tuple[Optional[ModuleSpec], bool]:
+    def _import_rust_file(self, module_path: str, module_name: str, file_path: Path) -> tuple[ModuleSpec | None, bool]:
         logger.debug('importing rust file "%s" as "%s"', file_path, module_path)
 
         with self._build_cache.lock() as build_cache:
@@ -253,7 +251,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
         source_path: Path,
         settings: MaturinSettings,
         build_cache: LockedBuildCache,
-    ) -> tuple[Optional[ModuleSpec], Optional[str]]:
+    ) -> tuple[ModuleSpec | None, str | None]:
         """Return a spec for the given module at the given search_dir if it exists and is newer than the source
         code that it is derived from.
         """
@@ -299,7 +297,7 @@ class MaturinRustFileImporter(importlib.abc.MetaPathFinder):
             logger.debug(message, prefix, module_path, maturin_output)
 
 
-def _find_extension_module(dir_path: Path, module_name: str, *, require: bool = False) -> Optional[Path]:
+def _find_extension_module(dir_path: Path, module_name: str, *, require: bool = False) -> Path | None:
     # the suffixes include the platform tag and file extension eg '.cpython-311-x86_64-linux-gnu.so'
     for suffix in importlib.machinery.EXTENSION_SUFFIXES:
         extension_path = dir_path / f"{module_name}{suffix}"
@@ -315,7 +313,7 @@ class _RustFileExtensionFileLoader(ExtensionFileLoader):
     pass
 
 
-def _get_spec_for_extension_module(module_path: str, extension_module_path: Path) -> Optional[ModuleSpec]:
+def _get_spec_for_extension_module(module_path: str, extension_module_path: Path) -> ModuleSpec | None:
     return importlib.util.spec_from_loader(
         module_path, _RustFileExtensionFileLoader(module_path, str(extension_module_path))
     )
@@ -372,16 +370,16 @@ class _ExtensionModuleReloader(_RustFileExtensionFileLoader):
                 del sys.modules[reload_name]
 
 
-IMPORTER: Optional[MaturinRustFileImporter] = None
+IMPORTER: MaturinRustFileImporter | None = None
 
 
 def install(
     *,
-    settings: Optional[MaturinSettings] = None,
-    build_dir: Optional[Path] = None,
+    settings: MaturinSettings | None = None,
+    build_dir: Path | None = None,
     enable_reloading: bool = True,
     force_rebuild: bool = False,
-    lock_timeout_seconds: Optional[float] = 120,
+    lock_timeout_seconds: float | None = 120,
     show_warnings: bool = True,
 ) -> MaturinRustFileImporter:
     """Install the 'rust file' importer to import .rs files as though

--- a/src/maturin_import_hook/settings.py
+++ b/src/maturin_import_hook/settings.py
@@ -2,7 +2,7 @@ import argparse
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import IO, Any, Literal, Optional, Union
+from typing import IO, Any, Literal
 
 __all__ = [
     "MaturinSettings",
@@ -16,28 +16,28 @@ class MaturinSettings:
     release: bool = False
     strip: bool = False
     quiet: bool = False
-    jobs: Optional[int] = None
-    profile: Optional[str] = None
-    features: Optional[list[str]] = None
+    jobs: int | None = None
+    profile: str | None = None
+    features: list[str] | None = None
     all_features: bool = False
     no_default_features: bool = False
-    target: Optional[str] = None
+    target: str | None = None
     ignore_rust_version: bool = False
-    color: Optional[bool] = None
+    color: bool | None = None
     frozen: bool = False
     locked: bool = False
     offline: bool = False
-    config: Optional[dict[str, str]] = None
-    unstable_flags: Optional[list[str]] = None
+    config: dict[str, str] | None = None
+    unstable_flags: list[str] | None = None
     verbose: int = 0
-    rustc_flags: Optional[list[str]] = None
+    rustc_flags: list[str] | None = None
 
     # `maturin build` specific
-    auditwheel: Optional[str] = None
+    auditwheel: str | None = None
     zig: bool = False
 
     # `maturin develop` specific
-    extras: Optional[list[str]] = None
+    extras: list[str] | None = None
     uv: bool = False
     skip_install: bool = False
 
@@ -145,7 +145,7 @@ class MaturinSettings:
         parser.add_argument("--target")
         parser.add_argument("--ignore-rust-version", action="store_true")
 
-        def parse_color(arg: str) -> Optional[bool]:
+        def parse_color(arg: str) -> bool | None:
             if arg == "always":
                 return True
             elif arg == "never":
@@ -181,10 +181,10 @@ class NonExitingArgumentParser(argparse.ArgumentParser):
         msg = "argument parser error"
         raise ValueError(msg)
 
-    def exit(self, status: int = 0, message: Optional[str] = None) -> None:  # type: ignore[override]
+    def exit(self, status: int = 0, message: str | None = None) -> None:  # type: ignore[override]
         pass
 
-    def _print_message(self, message: str, file: Optional[IO[str]] = None) -> None:  # type: ignore[override]
+    def _print_message(self, message: str, file: IO[str] | None = None) -> None:  # type: ignore[override]
         pass
 
 
@@ -195,8 +195,8 @@ class _KeyValueAction(argparse.Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        values: Union[str, Sequence[Any], None],
-        option_string: Union[str, Sequence[Any], None] = None,
+        values: str | Sequence[Any] | None,
+        option_string: str | Sequence[Any] | None = None,
     ) -> None:
         if values is None:
             values = []

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,13 +5,11 @@ These tests ensure that the import hook behaves correctly when installing a wide
 The recommended way to run the tests is to run:
 
 ```bash
+# run only after changing between maturin versions or after the first commit
 git submodule update --init ./maturin
 
-# run with the active interpreter
-python runner.py
-
-# or run with an interpreter installed via uv
-uv run --no-project --python 3.13t runner.py
+# run the tests. interesting interpreter versions to try are the minimum supported, latest and free-threading variants
+uv run --no-project --python 3.11 runner.py
 ```
 
 This script will create an isolated environment for the tests to run in

--- a/tests/create_benchmark_data.py
+++ b/tests/create_benchmark_data.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import random
@@ -24,7 +26,7 @@ class BenchmarkConfig:
     num_python_editable_packages: int
 
     @staticmethod
-    def default() -> "BenchmarkConfig":
+    def default() -> BenchmarkConfig:
         return BenchmarkConfig(
             seed=0,
             filename_length=10,

--- a/tests/reference/reloading/extension_module_properties.py
+++ b/tests/reference/reloading/extension_module_properties.py
@@ -1,4 +1,4 @@
-# ruff: noqa: INP001
+# ruff: noqa: INP001, PLC0415
 import importlib
 import importlib.machinery
 import logging

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -10,7 +10,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-# ruff: noqa: INP001, E402
+# ruff: noqa: E402
 
 
 script_dir = Path(__file__).resolve().parent
@@ -239,7 +239,6 @@ def main() -> None:
         action="store_true",
         help="re-create the workspace if it already exists",
     )
-
     parser.add_argument(
         "test_specification", nargs="?", help="the directory, file or test to run (defaults to running all tests)"
     )

--- a/tests/test_import_hook/common.py
+++ b/tests/test_import_hook/common.py
@@ -11,12 +11,12 @@ import sys
 import sysconfig
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, TypeVar
 
 script_dir = Path(__file__).resolve().parent
 log = logging.getLogger(__name__)
@@ -66,10 +66,10 @@ RELOAD_SUPPORTED = platform.system() != "Windows" and sys.version_info >= (3, 9)
 @dataclass
 class ResolvedPackage:
     cargo_manifest_path: Path
-    extension_module_dir: Optional[Path]
+    extension_module_dir: Path | None
     module_full_name: str
     python_dir: Path
-    python_module: Optional[Path]
+    python_module: Path | None
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ResolvedPackage":
@@ -85,10 +85,10 @@ class ResolvedPackage:
         return json.dumps({k: str(v) for k, v in dataclasses.asdict(self).items()}, indent=2, sort_keys=True)
 
 
-_RESOLVED_PACKAGES: Optional[dict[str, Optional[ResolvedPackage]]] = None
+_RESOLVED_PACKAGES: dict[str, ResolvedPackage | None] | None = None
 
 
-def resolved_packages() -> dict[str, Optional[ResolvedPackage]]:
+def resolved_packages() -> dict[str, ResolvedPackage | None]:
     global _RESOLVED_PACKAGES
     if _RESOLVED_PACKAGES is None:
         with (script_dir / "../resolved.json").open() as f:
@@ -114,7 +114,7 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
-def map_optional(value: Optional[T], f: Callable[[T], U]) -> Optional[U]:
+def map_optional(value: T | None, f: Callable[[T], U]) -> U | None:
     return None if value is None else f(value)
 
 
@@ -147,9 +147,9 @@ def run_python(
     *,
     quiet: bool = False,
     expect_error: bool = False,
-    profile: Optional[Path] = None,
-    env: Optional[dict[str, Any]] = None,
-    interpreter: Optional[Path] = None,
+    profile: Path | None = None,
+    env: dict[str, Any] | None = None,
+    interpreter: Path | None = None,
 ) -> tuple[str, float]:
     start = time.perf_counter()
 
@@ -202,12 +202,12 @@ def run_python(
 def run_python_code(
     python_script: str,
     *,
-    args: Optional[list[str]] = None,
-    cwd: Optional[Path] = None,
+    args: list[str] | None = None,
+    cwd: Path | None = None,
     quiet: bool = False,
     expect_error: bool = False,
-    env: Optional[dict[str, Any]] = None,
-    interpreter: Optional[Path] = None,
+    env: dict[str, Any] | None = None,
+    interpreter: Path | None = None,
 ) -> tuple[str, float]:
     with tempfile.TemporaryDirectory("run_python_code") as tmpdir_str:
         tmpdir = Path(tmpdir_str)
@@ -243,7 +243,7 @@ def check_match(text: str, pattern: str, *, flags: int = 0) -> None:
     assert matches, f'text does not match pattern:\npattern: "{pattern}"\ntext:\n{text}'
 
 
-def get_string_between(text: str, start: str, end: str) -> Optional[str]:
+def get_string_between(text: str, start: str, end: str) -> str | None:
     start_index = text.find(start)
     if start_index == -1:
         return None
@@ -265,7 +265,7 @@ def missing_entrypoint_error_message_pattern(name: str) -> str:
 @dataclass
 class PythonProcessOutput:
     output: str
-    duration: Optional[float]
+    duration: float | None
     success: bool
 
 
@@ -318,7 +318,7 @@ def set_file_times(path: Path, times: tuple[float, float]) -> None:
 
 
 @contextmanager
-def capture_logs(log: Optional[logging.Logger] = None, level: int = logging.INFO) -> Iterator[StringIO]:
+def capture_logs(log: logging.Logger | None = None, level: int = logging.INFO) -> Iterator[StringIO]:
     out = StringIO()
     if log is None:
         log = logging.getLogger()

--- a/tests/test_import_hook/conftest.py
+++ b/tests/test_import_hook/conftest.py
@@ -16,7 +16,6 @@ logging.basicConfig(format="[%(name)s] [%(levelname)s] %(message)s", level=loggi
 
 log = logging.getLogger(__name__)
 
-
 log.info("running tests with %s", sys.executable)
 
 

--- a/tests/test_import_hook/file_importer_helpers/reload_helper.py
+++ b/tests/test_import_hook/file_importer_helpers/reload_helper.py
@@ -1,11 +1,10 @@
-# ruff: noqa: E402
+# ruff: noqa: PLC0415
 import importlib
 import logging
 import pickle
 import re
 import sys
 from pathlib import Path
-from typing import Union
 
 import maturin_import_hook
 
@@ -20,7 +19,7 @@ assert rs_path.exists()
 action = sys.argv[2]
 
 
-def _modify_module_num(num: Union[int, str]) -> None:
+def _modify_module_num(num: int | str) -> None:
     source = rs_path.read_text()
     source = re.sub("let num = .*;", f"let num = {num};", source)
     rs_path.write_text(source)

--- a/tests/test_import_hook/project_importer_helpers/reload_helper.py
+++ b/tests/test_import_hook/project_importer_helpers/reload_helper.py
@@ -1,11 +1,10 @@
-# ruff: noqa: E402
+# ruff: noqa: PLC0415
 import importlib
 import logging
 import pickle
 import re
 import sys
 from pathlib import Path
-from typing import Union
 
 import maturin_import_hook
 
@@ -19,7 +18,7 @@ assert rs_path.exists()
 action = sys.argv[2]
 
 
-def _modify_project_num(num: Union[int, str]) -> None:
+def _modify_project_num(num: int | str) -> None:
     source = rs_path.read_text()
     source = re.sub("let num = .*;", f"let num = {num};", source)
     rs_path.write_text(source)

--- a/tests/test_import_hook/test_utilities.py
+++ b/tests/test_import_hook/test_utilities.py
@@ -343,11 +343,11 @@ def test_resolve_project(project_name: str) -> None:
 
 
 def test_resolve_invalid_project(tmp_path: Path) -> None:
-    with pytest.raises(_ProjectResolveError, match="no pyproject.toml found"):
+    with pytest.raises(_ProjectResolveError, match=r"no pyproject.toml found"):
         _resolve_project(tmp_path)
 
     (tmp_path / "pyproject.toml").write_text("~not TOML~")
-    with pytest.raises(_ProjectResolveError, match="pyproject.toml failed to parse as TOML: .*"):
+    with pytest.raises(_ProjectResolveError, match=r"pyproject.toml failed to parse as TOML: .*"):
         _resolve_project(tmp_path)
 
     (tmp_path / "pyproject.toml").write_text("")
@@ -358,11 +358,11 @@ def test_resolve_invalid_project(tmp_path: Path) -> None:
 
     (tmp_path / "pyproject.toml").write_text("[build-system]\nrequires = []")
 
-    with pytest.raises(_ProjectResolveError, match="no Cargo.toml found"):
+    with pytest.raises(_ProjectResolveError, match=r"no Cargo.toml found"):
         _resolve_project(tmp_path)
 
     (tmp_path / "Cargo.toml").write_text("~not TOML~")
-    with pytest.raises(_ProjectResolveError, match="Cargo.toml failed to parse as TOML: .*"):
+    with pytest.raises(_ProjectResolveError, match=r"Cargo.toml failed to parse as TOML: .*"):
         _resolve_project(tmp_path)
 
     (tmp_path / "Cargo.toml").write_text("")

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,15 @@
 version = 1
-revision = 2
-requires-python = ">=3.9"
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
 
 [[package]]
 name = "filelock"
@@ -12,55 +21,72 @@ wheels = [
 ]
 
 [[package]]
-name = "maturin-import-hook"
-version = "0.2.0"
-source = { editable = "." }
-dependencies = [
-    { name = "filelock" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "filelock" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.1.0" },
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
-name = "tomli"
-version = "2.2.1"
+name = "maturin-import-hook"
+version = "0.3.0"
+source = { editable = "." }
+dependencies = [
+    { name = "filelock" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "filelock" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.4.2" }]
+
+[[package]]
+name = "packaging"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
-    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
-    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
-    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
-    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
-    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
-    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
-    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
-    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
-    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]


### PR DESCRIPTION
upgrade to python 3.11 and upgrade all linters to the latest versions.

python 3.10 is EOL in a few months ([source](https://devguide.python.org/versions/)) so I jumped from 3.9 to 3.11