### PR TITLE
upgrade to maturin 1.14.1 (PR 3/3)

### DIFF
--- a/src/maturin_import_hook/_resolve_project.py
+++ b/src/maturin_import_hook/_resolve_project.py
@@ -112,9 +112,14 @@ class MaturinProject:
     # the path to the top level python package if the project is mixed
     python_module: Path | None
     # the location that the compiled extension module is written to when installed in editable/unpacked mode
+    # None for bin projects (no compiled extension module)
     extension_module_dir: Path | None
     # path dependencies listed in the Cargo.toml of the main project
     immediate_path_dependencies: list[Path]
+    # the maturin bindings type
+    bindings: str
+    # the names of binaries produced by this project (for bindings="bin" projects)
+    binary_names: list[str]
     # all path dependencies including transitive dependencies
     _all_path_dependencies: list[Path] | None = None
 
@@ -128,8 +133,8 @@ class MaturinProject:
 
     @property
     def is_mixed(self) -> bool:
-        """Whether the project contains both python and rust code."""
-        return self.extension_module_dir is not None
+        """Whether the project installs a .pth file (has a Python module directory alongside Rust code)."""
+        return self.extension_module_dir is not None or (self.bindings == "bin" and self.python_module is not None)
 
     @property
     def all_path_dependencies(self) -> list[Path]:
@@ -197,7 +202,11 @@ def _resolve_project(project_dir: Path) -> MaturinProject:
         msg = "could not resolve module_full_name"
         raise _ProjectResolveError(msg)
 
+    bindings = _resolve_bindings(pyproject, cargo)
+    binary_names = _resolve_binary_names(cargo, manifest_path.parent) if bindings == "bin" else []
+
     python_dir = _resolve_py_root(project_dir, pyproject)
+    python_source_explicit = pyproject.get_value(["tool", "maturin", "python-source"], str) is not None
 
     extension_module_dir: Path | None
     python_module: Path | None
@@ -205,6 +214,9 @@ def _resolve_project(project_dir: Path) -> MaturinProject:
     immediate_path_dependencies = _get_immediate_path_dependencies(manifest_path.parent, cargo)
 
     if not python_module.exists():
+        if python_source_explicit:
+            msg = f"python-source '{python_dir}' does not contain module '{module_full_name}'"
+            raise _ProjectResolveError(msg)
         extension_module_dir = None
         python_module = None
 
@@ -215,6 +227,8 @@ def _resolve_project(project_dir: Path) -> MaturinProject:
         python_module=python_module,
         extension_module_dir=extension_module_dir,
         immediate_path_dependencies=immediate_path_dependencies,
+        bindings=bindings,
+        binary_names=binary_names,
     )
 
 
@@ -275,6 +289,30 @@ def _get_immediate_path_dependencies(manifest_dir_path: Path, cargo: _TomlFile) 
     return path_dependencies
 
 
+def has_experimental_inspect(project_dir: Path) -> bool:
+    """Check if the project has the pyo3 `experimental-inspect` feature enabled.
+
+    This feature enables automatic stub generation when combined with
+    `maturin develop --generate-stubs`.
+    """
+    manifest_path = find_cargo_manifest(project_dir)
+    if manifest_path is None:
+        return False
+    try:
+        cargo = _TomlFile.load(manifest_path)
+    except tomllib.TOMLDecodeError:
+        logger.info("failed to parse '%s' as TOML", manifest_path)
+        return False
+
+    cargo_deps = cargo.get_value_or_default(["dependencies"], dict, {})
+    pyo3_dep = cargo_deps.get("pyo3")
+    if isinstance(pyo3_dep, dict):
+        features: Any = pyo3_dep.get("features", [])
+        if isinstance(features, list) and "experimental-inspect" in features:
+            return True
+    return False
+
+
 def _resolve_py_root(project_dir: Path, pyproject: _TomlFile) -> Path:
     """This follows the same logic as project_layout.rs."""
     py_root = pyproject.get_value(["tool", "maturin", "python-source"], str)
@@ -296,3 +334,64 @@ def _resolve_py_root(project_dir: Path, pyproject: _TomlFile) -> Path:
         return project_dir / "src"
     else:
         return project_dir
+
+
+def _resolve_bindings(pyproject: _TomlFile, cargo: _TomlFile) -> str:
+    """Resolve the maturin bindings type.
+
+    Matches maturin's bridge detection logic (bridge/detection.rs):
+    """
+    bindings = pyproject.get_value(["tool", "maturin", "bindings"], str)
+    if bindings is not None:
+        return bindings
+
+    cargo_deps = cargo.get_value_or_default(["dependencies"], dict, {})
+
+    if "pyo3" in cargo_deps or "pyo3-ffi" in cargo_deps:
+        return "pyo3"
+
+    if "uniffi" in cargo_deps:
+        return "uniffi"
+
+    lib = cargo.get_value(["lib"], dict)
+    if lib is not None:
+        crate_types = lib.get("crate-type")
+        if isinstance(crate_types, list) and "cdylib" in crate_types:
+            return "cffi"
+
+    bins = cargo.get_value(["bin"], list)
+    if bins is not None and len(bins) > 0:
+        return "bin"
+
+    return "pyo3"
+
+
+def _resolve_binary_names(cargo: _TomlFile, project_dir: Path) -> list[str]:
+    """Resolve binary names from Cargo.toml."""
+    bins = cargo.get_value(["bin"], list)
+    if bins is not None:
+        return [
+            str(bin_entry.get("name"))
+            for bin_entry in bins
+            if isinstance(bin_entry, dict) and bin_entry.get("name") is not None
+        ]
+
+    binary_names: list[str] = []
+    src_dir = project_dir / "src"
+    if (src_dir / "main.rs").is_file():
+        package_name = cargo.get_value(["package", "name"], str)
+        if package_name is not None:
+            binary_names.append(package_name)
+    bin_dir = src_dir / "bin"
+    if bin_dir.is_dir():
+        binary_names.extend(
+            rs_file.stem for rs_file in bin_dir.iterdir() if rs_file.is_file() and rs_file.suffix == ".rs"
+        )
+
+    if binary_names:
+        return sorted(binary_names)
+
+    package_name = cargo.get_value(["package", "name"], str)
+    if package_name is not None:
+        return [package_name]
+    return []

--- a/src/maturin_import_hook/project_importer.py
+++ b/src/maturin_import_hook/project_importer.py
@@ -1,4 +1,5 @@
 import contextlib
+import dataclasses
 import importlib
 import importlib.abc
 import importlib.machinery
@@ -8,6 +9,7 @@ import logging
 import os
 import site
 import sys
+import sysconfig
 import tempfile
 import time
 import urllib.parse
@@ -35,6 +37,7 @@ from maturin_import_hook._logging import logger
 from maturin_import_hook._resolve_project import (
     MaturinProject,
     ProjectResolver,
+    has_experimental_inspect,
     is_maybe_maturin_project,
 )
 from maturin_import_hook.error import ImportHookError
@@ -56,13 +59,13 @@ class ProjectFileSearcher(ABC):
         self,
         project_dir: Path,
         all_path_dependencies: list[Path],
-        installed_package_root: Path,
+        installed_package_roots: list[Path],
     ) -> Iterator[Path]:
         """find the files corresponding to the source code of the given project"""
         raise NotImplementedError
 
     @abstractmethod
-    def get_installation_paths(self, installed_package_root: Path) -> Iterator[Path]:
+    def get_installation_paths(self, installed_package_roots: list[Path]) -> Iterator[Path]:
         """find the files corresponding to the installed files of the given project"""
         raise NotImplementedError
 
@@ -95,7 +98,10 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
 
     def get_settings(self, module_path: str, source_path: Path) -> MaturinSettings:
         """This method can be overridden in subclasses to customize settings for specific projects."""
-        return self._settings if self._settings is not None else MaturinSettings.default()
+        settings = self._settings if self._settings is not None else MaturinSettings.default()
+        if not settings.generate_stubs and has_experimental_inspect(source_path):
+            settings = dataclasses.replace(settings, generate_stubs=True)
+        return settings
 
     def find_maturin(self) -> Path:
         """this method can be overridden to specify an alternative maturin binary to use"""
@@ -273,11 +279,12 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
                 msg = f'cannot find package "{package_name}" after installation'
                 raise ImportHookError(msg)
 
-            installed_package_root = _find_installed_package_root(resolved, spec)
-            if installed_package_root is None:
+            installed_package_roots = _find_installed_package_roots(resolved, spec)
+            if installed_package_roots is None:
                 logger.error("could not get installed package root")
             else:
-                mtime = get_installation_mtime(self._file_searcher.get_installation_paths(installed_package_root))
+                installed_paths = self._file_searcher.get_installation_paths(installed_package_roots)
+                mtime = get_installation_mtime(installed_paths)
                 if mtime is None:
                     logger.error("could not get installed package mtime")
                 else:
@@ -306,8 +313,8 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
         if spec is None:
             return None, "package not already installed"
 
-        installed_package_root = _find_installed_package_root(resolved, spec)
-        if installed_package_root is None:
+        installed_package_roots = _find_installed_package_roots(resolved, spec)
+        if installed_package_roots is None:
             return None, "could not find installed package root"
 
         build_status = build_cache.get_build_status(project_dir)
@@ -318,9 +325,9 @@ class MaturinProjectImporter(importlib.abc.MetaPathFinder):
         if build_status.maturin_args != settings.to_args("develop"):
             return None, "current maturin args do not match the previous build"
 
-        installed_paths = self._file_searcher.get_installation_paths(installed_package_root)
+        installed_paths = self._file_searcher.get_installation_paths(installed_package_roots)
         source_paths = self._file_searcher.get_source_paths(
-            project_dir, resolved.all_path_dependencies, installed_package_root
+            project_dir, resolved.all_path_dependencies, installed_package_roots
         )
         freshness = get_installation_freshness(source_paths, installed_paths, build_status)
         if not freshness.is_fresh:
@@ -434,23 +441,46 @@ def _uri_to_path(uri: str) -> Path:
     return Path(os.path.normpath(os.path.join(host, path)))  # noqa: PTH118
 
 
-def _find_installed_package_root(resolved: MaturinProject, package_spec: ModuleSpec) -> Path | None:
-    """Find the root of the files that change each time the project is rebuilt:
+def _find_installed_package_roots(resolved: MaturinProject, package_spec: ModuleSpec) -> list[Path] | None:
+    """Find the roots of the files that change each time the project is rebuilt:
     - for mixed projects: the root directory or file of the extension module inside the source tree
+    - for bin projects: the installed binaries in the venv bin/scripts directory
     - for pure projects: the root directory of the installed package.
+
+    Returns None if no installation roots could be found.
     """
-    if resolved.extension_module_dir is not None:
+    roots: list[Path] = []
+    if resolved.bindings == "bin" and resolved.binary_names:
+        roots.extend(_find_installed_binaries(resolved.binary_names))
+    elif resolved.extension_module_dir is not None:
         installed_package_root = _find_extension_module(
             resolved.extension_module_dir, resolved.module_name, require=False
         )
         if installed_package_root is None:
             logger.debug('no extension module found in "%s"', resolved.extension_module_dir)
-        return installed_package_root
+        else:
+            roots.append(installed_package_root)
     elif package_spec.origin is not None:
-        return Path(package_spec.origin).parent
+        roots.append(Path(package_spec.origin).parent)
     else:
         logger.debug("could not find installation location for pure package")
+
+    if not roots:
         return None
+    return roots
+
+
+def _find_installed_binaries(binary_names: list[str]) -> list[Path]:
+    """Find installed binaries in the scripts directory."""
+    scripts_dir = Path(sysconfig.get_path("scripts"))
+    binaries: list[Path] = []
+    for name in binary_names:
+        binary_path = scripts_dir / name
+        if not binary_path.exists():
+            binary_path = scripts_dir / f"{name}.exe"
+        if binary_path.exists():
+            binaries.append(binary_path)
+    return binaries
 
 
 def _find_extension_module(dir_path: Path, module_name: str, *, require: bool = False) -> Path | None:
@@ -510,6 +540,7 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
         ".so",
         ".py",
         ".pyc",
+        ".pyi",  # generated stub files from `maturin --generate-stubs`
     }
 
     def __init__(
@@ -549,14 +580,15 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
         self,
         project_dir: Path,
         all_path_dependencies: list[Path],
-        installed_package_root: Path,
+        installed_package_roots: list[Path],
     ) -> Iterator[Path]:
         excluded_dirs = set()
         excluded_files = set()
-        if installed_package_root.is_dir():
-            excluded_dirs.add(installed_package_root)
-        else:
-            excluded_files.add(installed_package_root)
+        for root in installed_package_roots:
+            if root.is_dir():
+                excluded_dirs.add(root)
+            else:
+                excluded_files.add(root)
 
         for root_dir in itertools.chain((project_dir,), all_path_dependencies):
             for path in self.get_files_in_dir(
@@ -569,13 +601,12 @@ class DefaultProjectFileSearcher(ProjectFileSearcher):
                 if path not in excluded_files:
                     yield path
 
-    def get_installation_paths(self, installed_package_root: Path) -> Iterator[Path]:
-        if installed_package_root.is_dir():
-            yield from self.get_files_in_dir(installed_package_root, set(), {"__pycache__"}, set(), {".pyc"})
-        elif installed_package_root.is_file():
-            yield installed_package_root
-        else:
-            return
+    def get_installation_paths(self, installed_package_roots: list[Path]) -> Iterator[Path]:
+        for root in installed_package_roots:
+            if root.is_dir():
+                yield from self.get_files_in_dir(root, set(), {"__pycache__"}, set(), {".pyc"})
+            elif root.is_file():
+                yield root
 
     def get_files_in_dir(
         self,

--- a/src/maturin_import_hook/rust_file_importer.py
+++ b/src/maturin_import_hook/rust_file_importer.py
@@ -337,27 +337,28 @@ class _ExtensionModuleReloader(_RustFileExtensionFileLoader):
         path: str
 
     def exec_module(self, module: ModuleType) -> None:
-        if sys.modules[self.name] is not module:
+        if sys.modules.get(self.name) is not module:
             msg = f"failed to reload {self.name}. Module not in sys.modules"
             raise ImportHookError(msg)
 
-        reload_name = f"maturin_import_hook._reload.{self.name}"
         try:
             logger.debug("creating new module then moving into %s", self.name)
 
-            loader = ExtensionFileLoader(reload_name, self.reload_path)
-            spec = importlib.util.spec_from_loader(reload_name, loader)
+            # Temporarily remove from sys.modules so module_from_spec creates a new module
+            sys.modules.pop(self.name)
+
+            loader = ExtensionFileLoader(self.name, self.reload_path)
+            spec = importlib.util.spec_from_loader(self.name, loader)
             if spec is None:
                 msg = f"failed to create spec for {self.name} during reload"
                 raise ImportHookError(msg)
 
             reloaded_module = importlib.util.module_from_spec(spec)
+            # module_from_spec doesn't call exec_module for extension modules,
+            # so we need to call it manually to run the init function
+            loader.exec_module(reloaded_module)
             if reloaded_module is module:
                 msg = f"failed to create new module for {self.name} during reload"
-                raise ImportHookError(msg)
-
-            if sys.modules[self.name] is reloaded_module:
-                msg = f"expected a new module to be created for {self.name}"
                 raise ImportHookError(msg)
 
             excluded_names = {"__name__", "__file__", "__package__", "__loader__", "__spec__"}
@@ -365,9 +366,13 @@ class _ExtensionModuleReloader(_RustFileExtensionFileLoader):
             for k, v in reloaded_module.__dict__.items():
                 if k not in excluded_names:
                     module.__dict__[k] = v
+
+            # Restore the original module object in sys.modules
+            sys.modules[self.name] = module
         finally:
-            if reload_name in sys.modules:
-                del sys.modules[reload_name]
+            # Clean up if something went wrong
+            if sys.modules.get(self.name) is not module:
+                sys.modules[self.name] = module
 
 
 IMPORTER: MaturinRustFileImporter | None = None

--- a/src/maturin_import_hook/settings.py
+++ b/src/maturin_import_hook/settings.py
@@ -38,8 +38,10 @@ class MaturinSettings:
 
     # `maturin develop` specific
     extras: list[str] | None = None
+    group: list[str] | None = None
     uv: bool = False
     skip_install: bool = False
+    generate_stubs: bool = False
 
     @staticmethod
     def default() -> "MaturinSettings":
@@ -108,10 +110,15 @@ class MaturinSettings:
             if self.extras is not None:
                 args.append("--extras")
                 args.append(",".join(self.extras))
+            if self.group is not None:
+                args.append("--group")
+                args.append(",".join(self.group))
             if self.uv:
                 args.append("--uv")
             if self.skip_install:
                 args.append("--skip-install")
+            if self.generate_stubs:
+                args.append("--generate-stubs")
 
         if self.rustc_flags is not None:
             args.append("--")
@@ -168,8 +175,10 @@ class MaturinSettings:
 
         # `maturin develop` specific
         parser.add_argument("-E", "--extras", type=lambda arg: arg.split(","), action="extend")
+        parser.add_argument("-G", "--group", type=lambda arg: arg.split(","), action="extend")
         parser.add_argument("--uv", action="store_true")
         parser.add_argument("--skip-install", action="store_true")
+        parser.add_argument("--generate-stubs", action="store_true")
 
         return parser
 

--- a/tests/package_resolver/Cargo.lock
+++ b/tests/package_resolver/Cargo.lock
@@ -85,16 +85,32 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
 dependencies = [
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
+name = "arwen"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+checksum = "d44cbd9bd79165abe331ebabb9dd4d59a5dc93791be33ff15ebd71baaadc85ba"
 dependencies = [
- "derive_arbitrary",
+ "clap",
+ "goblin",
+ "object 0.38.1",
+ "scroll",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "arwen-codesign"
+version = "0.0.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d7a19757bfe3658d5a95bf25a0492f29ebb21933549bdbfa4075c895510124"
+dependencies = [
+ "goblin",
+ "scroll",
+ "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]
@@ -102,12 +118,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -129,6 +139,21 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boxcar"
@@ -166,27 +191,17 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytesize"
-version = "1.3.3"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -222,10 +237,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-options"
-version = "0.7.6"
+name = "cargo-cyclonedx"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89e1d6d6f65fe04d5e21be9de19d31a074e3b7e43aa39ee5b85f4cee16c3188"
+checksum = "5d162f67705f0f5038759d73bf546a083bf30e8677c2e944b416bca48d9d69a8"
+dependencies = [
+ "anyhow",
+ "cargo-lock",
+ "cargo_metadata 0.18.1",
+ "clap",
+ "cyclonedx-bom",
+ "env_logger",
+ "log",
+ "once_cell",
+ "pathdiff",
+ "percent-encoding",
+ "purl",
+ "regex",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "validator",
+]
+
+[[package]]
+name = "cargo-lock"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06acb4f71407ba205a07cb453211e0e6a67b21904e47f6ba1f9589e38f2e454"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 0.8.23",
+ "url",
+]
+
+[[package]]
+name = "cargo-options"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b916a16b2a4b0ce91d46e42c51b7fc42e754220a4cc8bbfd1947efaafea99af7"
 dependencies = [
  "anstyle",
  "clap",
@@ -241,10 +292,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-xwin"
-version = "0.18.6"
+name = "cargo-platform"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dff83aad332bd6ee29072dd874b48892cd22c58e233c25735eb4417b3999685"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-xwin"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a978d433c17ee532d4cb0a8ec9b7aeb121e658267ac1c637504583b12b2861"
 dependencies = [
  "anyhow",
  "cargo-config2",
@@ -256,10 +317,7 @@ dependencies = [
  "indicatif",
  "paste",
  "path-slash",
- "rustls",
- "rustls-pemfile",
  "serde",
- "serde_json",
  "tar",
  "tracing-subscriber",
  "ureq",
@@ -270,37 +328,53 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9584d77470f7ffea2fb67fbcc9e8dbe9fa79a80dafd579a83507c0a08d1f658"
+checksum = "68c7df45b9d9934aaed5987fbf422b31419f81827b13a52251a61e1e772c6ff7"
 dependencies = [
  "anyhow",
  "cargo-config2",
  "cargo-options",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "clap",
  "crc",
  "dirs",
  "fs-err",
+ "goblin",
  "path-slash",
  "rustc_version",
  "rustflags",
+ "scroll",
  "semver",
  "serde",
  "serde_json",
- "shlex 1.3.0",
+ "shell-words",
  "target-lexicon",
  "which",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.3",
  "semver",
  "serde",
  "serde_json",
@@ -309,11 +383,11 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.28.0"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
@@ -322,28 +396,36 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
- "shlex 2.0.1",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
-name = "cfb"
-version = "0.10.0"
+name = "cesu8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a4f8e55be323b378facfcf1f06aa97f6ec17cf4ac84fb17325093aaf62da41"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a347dcabdae9c31b0825fd6a8bed285ec9c2acb89c47827126d52fa4f59cece3"
 dependencies = [
- "byteorder",
  "fnv",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -358,7 +440,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "encoding_rs",
 ]
 
@@ -435,7 +517,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -449,12 +531,12 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-table"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53f9241f288a7b12c56565f04aaeaeeab6b8923d42d99255d4ca428b4d97f89"
+checksum = "14da8d951cef7cc4f13ccc9b744d736963d57863c7e6fc33c070ea274546082c"
 dependencies = [
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -464,6 +546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "configparser"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,22 +563,81 @@ checksum = "b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -560,6 +711,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "cyclonedx-bom"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3132b69ba8c13808bd2fa5748ac5b9816eb4f4e1f0bff6b7f9254a5940dcdeef"
+dependencies = [
+ "base64",
+ "cyclonedx-bom-macros",
+ "fluent-uri",
+ "indexmap",
+ "once_cell",
+ "ordered-float",
+ "purl",
+ "regex",
+ "serde",
+ "serde_json",
+ "spdx",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
+ "xml-rs",
+]
+
+[[package]]
+name = "cyclonedx-bom-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50341f21df64b412b4f917e34b7aa786c092d64f3f905f478cb76950c7e980c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,25 +767,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
  "console",
  "shell-words",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -600,29 +783,40 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -634,6 +828,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -664,10 +867,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
+name = "env_logger"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "equivalent"
@@ -697,7 +907,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bed3960cfd332df43d86b2ae31bfed07a7b727a6170ae65dddc342775e810ca7"
 dependencies = [
- "goblin 0.10.7",
+ "goblin",
 ]
 
 [[package]]
@@ -728,6 +938,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +959,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -834,24 +1061,13 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
-dependencies = [
- "log",
- "plain",
- "scroll 0.12.0",
-]
-
-[[package]]
-name = "goblin"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17582616a7718cca54cec18e534a76c7c4aec11a8b9a85695712f262fd15a4c8"
 dependencies = [
  "log",
  "plain",
- "scroll 0.13.0",
+ "scroll",
 ]
 
 [[package]]
@@ -862,7 +1078,16 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -873,21 +1098,52 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1022,15 +1278,26 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.2",
+ "unicode-width",
+ "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1038,15 +1305,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1058,10 +1316,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1082,14 +1403,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lddtree"
-version = "0.3.8"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547a362ad16dead8837d5b30402a81b05bb57c352044389f8748f4f2dbd51914"
+checksum = "62b602caaaa7782b416e6f819fe721822045a9163aa03083e6309c260f1ce9b3"
 dependencies = [
  "fs-err",
  "glob",
- "goblin 0.10.7",
+ "goblin",
+ "memmap2",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -1128,6 +1456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1475,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "lzma-sys"
@@ -1181,16 +1524,19 @@ dependencies = [
 
 [[package]]
 name = "maturin"
-version = "1.8.6"
+version = "1.14.1"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "arwen",
+ "arwen-codesign",
+ "base64",
  "bytesize",
  "cargo-config2",
+ "cargo-cyclonedx",
  "cargo-options",
  "cargo-xwin",
  "cargo-zigbuild",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "cbindgen",
  "cc",
  "clap",
@@ -1204,45 +1550,51 @@ dependencies = [
  "flate2",
  "fs-err",
  "glob",
- "goblin 0.9.3",
+ "goblin",
  "ignore",
  "indexmap",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "lddtree",
+ "memmap2",
  "minijinja",
- "multipart",
  "normpath",
  "once_cell",
  "path-slash",
  "pep440_rs",
  "pep508_rs",
  "platform-info",
+ "pyo3-introspection",
  "pyproject-toml",
  "python-pkginfo",
+ "reflink-copy",
  "regex",
  "rustc_version",
+ "rustflags",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "same-file",
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "target-lexicon",
  "tempfile",
  "textwrap",
  "thiserror 2.0.18",
  "time",
- "toml 0.8.23",
- "toml_edit",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "unicode-xid",
  "ureq",
  "url",
+ "walkdir",
+ "which",
  "wild",
- "zip 2.4.2",
+ "xz2",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1250,6 +1602,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memo-map"
@@ -1293,12 +1654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "msi"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2332f87a064dea9cce571408c879e0da8dc193b3af06a2b3b2604ee4182a32"
+checksum = "b0325f8473ef1f5c38ee42345e2cd1678299cbbfa169d1776654a2a682867420"
 dependencies = [
  "byteorder",
  "cfb",
@@ -1321,26 +1676,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "log",
- "mime",
- "mime_guess",
- "rand",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1368,10 +1709,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
+name = "num-traits"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -1380,6 +1724,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -1395,10 +1753,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "package_resolver"
@@ -1446,6 +1819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+dependencies = [
+ "camino",
+]
+
+[[package]]
 name = "pep440_rs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,7 +1836,7 @@ dependencies = [
  "once_cell",
  "serde",
  "tracing",
- "unicode-width 0.2.2",
+ "unicode-width",
  "unscanny",
  "version-ranges",
 ]
@@ -1476,7 +1858,7 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tracing",
- "unicode-width 0.2.2",
+ "unicode-width",
  "url",
  "urlencoding",
  "version-ranges",
@@ -1487,6 +1869,50 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+ "unicase",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1538,15 +1964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,11 +1983,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "purl"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ebe4262ae91ddd28c8721111a0a6e9e58860e211fc92116c4bb85c98fd96ad"
+dependencies = [
+ "hex",
+ "percent-encoding",
+ "phf",
+ "thiserror 2.0.18",
+ "unicase",
+]
+
+[[package]]
+name = "pyo3-introspection"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7775fcc875acdce3872dcb91a4b7bd155ffba6e0ea8be88b8caab7d0b34539a6"
+dependencies = [
+ "anyhow",
+ "goblin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pyproject-toml"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d755483ad14b49e76713b52285235461a5b4f73f17612353e11a5de36a5fd2"
 dependencies = [
+ "glob",
  "indexmap",
  "pep440_rs",
  "pep508_rs",
@@ -1617,22 +2060,10 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -1641,9 +2072,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rayon"
@@ -1676,13 +2104,45 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
 ]
 
 [[package]]
@@ -1720,7 +2180,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b36447d5e70933adee73cefff22b0851edbc162f2b3951918de43717a22d92de"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "charset",
  "chumsky",
  "memchr",
@@ -1792,12 +2252,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
+ "openssl-probe",
  "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1808,6 +2271,33 @@ checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1827,12 +2317,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1843,31 +2351,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
-dependencies = [
- "scroll_derive 0.12.1",
-]
-
-[[package]]
-name = "scroll"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 dependencies = [
- "scroll_derive 0.13.1",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -1879,6 +2367,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1960,8 +2471,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1981,12 +2503,6 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -1996,6 +2512,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2027,6 +2549,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,16 +2577,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2142,7 +2688,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2187,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2201,10 +2747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2212,6 +2760,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2232,7 +2790,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2256,10 +2814,12 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 
@@ -2302,6 +2862,19 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2401,14 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand",
- "static_assertions",
-]
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-path"
@@ -2448,12 +3016,6 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -2463,6 +3025,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unscanny"
@@ -2478,21 +3046,38 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
+ "cookie_store",
  "flate2",
+ "getrandom 0.4.3",
  "log",
- "once_cell",
+ "mime_guess",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "socks",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -2515,6 +3100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,8 +3123,24 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -2559,11 +3166,11 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "versions"
-version = "6.3.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139"
+checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "nom",
 ]
 
@@ -2639,12 +3246,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
- "webpki-roots 1.0.8",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2658,14 +3265,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -2709,18 +3313,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -2752,17 +3451,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2782,10 +3481,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2795,9 +3503,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2807,9 +3515,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2825,9 +3533,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2837,9 +3545,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2849,9 +3557,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2861,9 +3569,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2885,12 +3593,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "writeable"
@@ -2909,10 +3614,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "xwin"
-version = "0.6.5"
+name = "xml-rs"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7e4546db1514c186778f0a257d89732ed9ed75587d0953ac25be7519d9f0d1"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xwin"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c337699251ad0c38cf87ee63944de38c2201d017cfbb768e5a3897ae835aacc7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2930,16 +3641,16 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "twox-hash",
  "ureq",
  "versions",
  "walkdir",
- "zip 2.4.2",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -2972,26 +3683,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3056,21 +3747,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
- "arbitrary",
- "bzip2",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
- "time",
- "zopfli",
+ "typed-path",
 ]
 
 [[package]]
@@ -3079,12 +3764,16 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
+ "bzip2",
  "crc32fast",
  "flate2",
  "indexmap",
+ "lzma-rust2",
  "memchr",
+ "time",
  "typed-path",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -3109,4 +3798,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/tests/package_resolver/src/main.rs
+++ b/tests/package_resolver/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use maturin::BuildOptions;
+use maturin::{BridgeModel, BuildOptions};
 use serde_json::{json, Value};
 use std::{
     env, fs,
@@ -33,27 +33,46 @@ fn resolve_package(project_root: &Path) -> Result<Value> {
 
     let build_options: BuildOptions = Default::default();
     let build_context = build_options.into_build_context().build()?;
-    let extension_module_dir = if build_context.project_layout.python_module.is_some() {
+    let extension_module_dir = if build_context.project.project_layout.python_module.is_some() {
         Some(relative_path(
-            &build_context.project_layout.rust_module,
+            &build_context.project.project_layout.rust_module,
             &project_root,
         )?)
     } else {
         None
     };
-    let python_module = if let Some(p) = &build_context.project_layout.python_module {
+    let python_module = if let Some(p) = &build_context.project.project_layout.python_module {
         Some(relative_path(p, &project_root)?)
     } else {
         None
     };
+    let bindings = bridge_name(build_context.project.bridge()).to_owned();
+    let binary_names: Vec<String> = build_context
+        .project
+        .compile_targets
+        .iter()
+        .filter(|ct| ct.bridge_model.is_bin())
+        .map(|ct| ct.target.name.clone())
+        .collect();
 
     Ok(json!({
-        "cargo_manifest_path": relative_path(&build_context.manifest_path, &project_root)?,
+        "binary_names": binary_names,
+        "bindings": bindings,
+        "cargo_manifest_path": relative_path(&build_context.project.manifest_path, &project_root)?,
         "extension_module_dir": extension_module_dir,
-        "module_full_name": build_context.module_name,
-        "python_dir": relative_path(&build_context.project_layout.python_dir, &project_root)?,
+        "module_full_name": build_context.project.module_name,
+        "python_dir": relative_path(&build_context.project.project_layout.python_dir, &project_root)?,
         "python_module": python_module,
     }))
+}
+
+fn bridge_name(bridge: &BridgeModel) -> &'static str {
+    match bridge {
+        BridgeModel::Bin(_) => "bin",
+        BridgeModel::PyO3(_) => "pyo3",
+        BridgeModel::Cffi => "cffi",
+        BridgeModel::UniFfi => "uniffi",
+    }
 }
 
 fn relative_path(p: &Path, root: &Path) -> Result<PathBuf> {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 -e ..
 uv
-maturin==1.8.4
+maturin==1.14.1
 pytest
 junit2html
 uniffi-bindgen==0.28.0

--- a/tests/resolved.json
+++ b/tests/resolved.json
@@ -1,14 +1,83 @@
 {
-  "commit": "c5fd4ce8eab655952bc5059c0a9e8372fb7890eb",
+  "commit": "6febbe20f0006e62299c6a88b49e3ede5e2e2318",
   "crates": {
+    "bin-with-python-module": {
+      "binary_names": [
+        "bin-with-python-module"
+      ],
+      "bindings": "bin",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "bin_with_python_module",
+      "module_full_name": "bin_with_python_module",
+      "python_dir": ".",
+      "python_module": "bin_with_python_module"
+    },
     "cffi-mixed": {
+      "binary_names": [],
+      "bindings": "cffi",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": "cffi_mixed",
       "module_full_name": "cffi_mixed",
       "python_dir": ".",
       "python_module": "cffi_mixed"
     },
+    "cffi-mixed-implicit": {
+      "binary_names": [],
+      "bindings": "cffi",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "python/cffi_mixed_implicit/some_rust",
+      "module_full_name": "cffi_mixed_implicit.some_rust.rust",
+      "python_dir": "python",
+      "python_module": "python/cffi_mixed_implicit"
+    },
+    "cffi-mixed-include-exclude": {
+      "binary_names": [],
+      "bindings": "cffi",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "cffi_mixed_include_exclude",
+      "module_full_name": "cffi_mixed_include_exclude",
+      "python_dir": ".",
+      "python_module": "cffi_mixed_include_exclude"
+    },
+    "cffi-mixed-py-subdir": {
+      "binary_names": [],
+      "bindings": "cffi",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "python/cffi_mixed_py_subdir",
+      "module_full_name": "cffi_mixed_py_subdir._cffi_mixed",
+      "python_dir": "python",
+      "python_module": "python/cffi_mixed_py_subdir"
+    },
+    "cffi-mixed-src": {
+      "binary_names": [],
+      "bindings": "cffi",
+      "cargo_manifest_path": "rust/Cargo.toml",
+      "extension_module_dir": "src/cffi_mixed_src",
+      "module_full_name": "cffi_mixed_src",
+      "python_dir": "src",
+      "python_module": "src/cffi_mixed_src"
+    },
+    "cffi-mixed-submodule": {
+      "binary_names": [],
+      "bindings": "cffi",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "cffi_mixed_submodule/rust_module",
+      "module_full_name": "cffi_mixed_submodule.rust_module.rust",
+      "python_dir": ".",
+      "python_module": "cffi_mixed_submodule"
+    },
+    "cffi-mixed-with-path-dep": {
+      "binary_names": [],
+      "bindings": "cffi",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "cffi_mixed_with_path_dep",
+      "module_full_name": "cffi_mixed_with_path_dep",
+      "python_dir": ".",
+      "python_module": "cffi_mixed_with_path_dep"
+    },
     "cffi-pure": {
+      "binary_names": [],
+      "bindings": "cffi",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "cffi_pure",
@@ -16,6 +85,11 @@
       "python_module": null
     },
     "hello-world": {
+      "binary_names": [
+        "foo",
+        "hello-world"
+      ],
+      "bindings": "bin",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "hello-world",
@@ -23,6 +97,8 @@
       "python_module": null
     },
     "lib_with_disallowed_lib": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "lib_with_disallowed_lib",
@@ -30,6 +106,8 @@
       "python_module": null
     },
     "lib_with_path_dep": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "lib_with_path_dep",
@@ -37,13 +115,37 @@
       "python_module": null
     },
     "license-test": {
+      "binary_names": [
+        "license-test"
+      ],
+      "bindings": "bin",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "license-test",
       "python_dir": ".",
       "python_module": null
     },
+    "pyo3-abi3-and-abi3t": {
+      "binary_names": [],
+      "bindings": "pyo3",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": null,
+      "module_full_name": "pyo3_abi3_and_abi3t",
+      "python_dir": ".",
+      "python_module": null
+    },
+    "pyo3-abi3t": {
+      "binary_names": [],
+      "bindings": "pyo3",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": null,
+      "module_full_name": "pyo3_abi3t",
+      "python_dir": ".",
+      "python_module": null
+    },
     "pyo3-ffi-pure": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "pyo3_ffi_pure",
@@ -51,20 +153,17 @@
       "python_module": null
     },
     "pyo3-mixed": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": "pyo3_mixed",
       "module_full_name": "pyo3_mixed",
       "python_dir": ".",
       "python_module": "pyo3_mixed"
     },
-    "pyo3-mixed-implicit": {
-      "cargo_manifest_path": "Cargo.toml",
-      "extension_module_dir": "python/pyo3_mixed_implicit/some_rust",
-      "module_full_name": "pyo3_mixed_implicit.some_rust.rust",
-      "python_dir": "python",
-      "python_module": "python/pyo3_mixed_implicit"
-    },
     "pyo3-mixed-include-exclude": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": "pyo3_mixed_include_exclude",
       "module_full_name": "pyo3_mixed_include_exclude",
@@ -72,6 +171,8 @@
       "python_module": "pyo3_mixed_include_exclude"
     },
     "pyo3-mixed-py-subdir": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": "python/pyo3_mixed_py_subdir",
       "module_full_name": "pyo3_mixed_py_subdir._pyo3_mixed",
@@ -79,27 +180,17 @@
       "python_module": "python/pyo3_mixed_py_subdir"
     },
     "pyo3-mixed-src": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "rust/Cargo.toml",
       "extension_module_dir": "src/pyo3_mixed_src",
       "module_full_name": "pyo3_mixed_src",
       "python_dir": "src",
       "python_module": "src/pyo3_mixed_src"
     },
-    "pyo3-mixed-submodule": {
-      "cargo_manifest_path": "Cargo.toml",
-      "extension_module_dir": "pyo3_mixed_submodule/rust_module",
-      "module_full_name": "pyo3_mixed_submodule.rust_module.rust",
-      "python_dir": ".",
-      "python_module": "pyo3_mixed_submodule"
-    },
-    "pyo3-mixed-with-path-dep": {
-      "cargo_manifest_path": "Cargo.toml",
-      "extension_module_dir": "pyo3_mixed_with_path_dep",
-      "module_full_name": "pyo3_mixed_with_path_dep",
-      "python_dir": ".",
-      "python_module": "pyo3_mixed_with_path_dep"
-    },
     "pyo3-mixed-workspace": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "rust/python/pyo3-mixed-workspace-py/Cargo.toml",
       "extension_module_dir": "src/pyo3_mixed_workspace",
       "module_full_name": "pyo3_mixed_workspace.pyo3_mixed_workspace_py",
@@ -107,13 +198,44 @@
       "python_module": "src/pyo3_mixed_workspace"
     },
     "pyo3-pure": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "pyo3_pure",
       "python_dir": ".",
       "python_module": null
     },
+    "pyo3-stub-generation-mixed": {
+      "binary_names": [],
+      "bindings": "pyo3",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "pyo3_stub_generation_mixed",
+      "module_full_name": "pyo3_stub_generation_mixed",
+      "python_dir": ".",
+      "python_module": "pyo3_stub_generation_mixed"
+    },
+    "pyo3-stub-generation-mixed-py-subdir": {
+      "binary_names": [],
+      "bindings": "pyo3",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": "python/pyo3_stub_generation_mixed_py_subdir",
+      "module_full_name": "pyo3_stub_generation_mixed_py_subdir._pyo3_mixed",
+      "python_dir": "python",
+      "python_module": "python/pyo3_stub_generation_mixed_py_subdir"
+    },
+    "pyo3-stub-generation-pure": {
+      "binary_names": [],
+      "bindings": "pyo3",
+      "cargo_manifest_path": "Cargo.toml",
+      "extension_module_dir": null,
+      "module_full_name": "pyo3_stub_generation_pure",
+      "python_dir": ".",
+      "python_module": null
+    },
     "sdist_with_path_dep": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "sdist_with_path_dep",
@@ -121,6 +243,8 @@
       "python_module": null
     },
     "sdist_with_target_path_dep": {
+      "binary_names": [],
+      "bindings": "pyo3",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "sdist_with_target_path_dep",
@@ -128,13 +252,26 @@
       "python_module": null
     },
     "uniffi-mixed": {
+      "binary_names": [],
+      "bindings": "uniffi",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": "uniffi_mixed",
       "module_full_name": "uniffi_mixed",
       "python_dir": ".",
       "python_module": "uniffi_mixed"
     },
+    "uniffi-multiple-crates": {
+      "binary_names": [],
+      "bindings": "uniffi",
+      "cargo_manifest_path": "crates/a/Cargo.toml",
+      "extension_module_dir": null,
+      "module_full_name": "a",
+      "python_dir": ".",
+      "python_module": null
+    },
     "uniffi-pure": {
+      "binary_names": [],
+      "bindings": "uniffi",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "uniffi_pure",
@@ -142,6 +279,8 @@
       "python_module": null
     },
     "uniffi-pure-proc-macro": {
+      "binary_names": [],
+      "bindings": "uniffi",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "uniffi_pure_proc_macro",
@@ -149,6 +288,8 @@
       "python_module": null
     },
     "with-data": {
+      "binary_names": [],
+      "bindings": "cffi",
       "cargo_manifest_path": "Cargo.toml",
       "extension_module_dir": null,
       "module_full_name": "with_data",
@@ -156,12 +297,6 @@
       "python_module": null
     },
     "workspace-inverted-order": null,
-    "wrong-python-source": {
-      "cargo_manifest_path": "Cargo.toml",
-      "extension_module_dir": null,
-      "module_full_name": "wrong-python-source",
-      "python_dir": "python",
-      "python_module": null
-    }
+    "wrong-python-source": null
   }
 }

--- a/tests/test_import_hook/common.py
+++ b/tests/test_import_hook/common.py
@@ -32,10 +32,11 @@ MATURIN_DIR = (script_dir / "../maturin").resolve()
 TEST_CRATES_DIR = MATURIN_DIR / "test-crates"
 
 IGNORED_TEST_CRATES = {
-    "hello-world",  # not imported as a python module (subprocess only)
-    "license-test",  # not imported as a python module (subprocess only)
-    "pyo3-bin",  # not imported as a python module (subprocess only)
+    "hello-world",  # an example more than a test case
+    "license-test",  # not an interesting test case
     "workspace-inverted-order",  # this directory is not a maturin package, only the subdirectory
+    "cffi-mixed-include-exclude",  # build-time generated files not excluded from import hook. Build always stale
+    "pyo3-mixed-include-exclude",  # build-time generated files not excluded from import hook. Build always stale
 }
 # these test-crates do not work with free-threaded python
 # (to verify: run `maturin develop` to install them into an appropriate virtualenv and try to run the
@@ -70,6 +71,8 @@ class ResolvedPackage:
     module_full_name: str
     python_dir: Path
     python_module: Path | None
+    bindings: str
+    binary_names: list[str]
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "ResolvedPackage":
@@ -79,6 +82,8 @@ class ResolvedPackage:
             module_full_name=data["module_full_name"],
             python_dir=Path(data["python_dir"]),
             python_module=map_optional(data["python_module"], Path),
+            bindings=data["bindings"],
+            binary_names=data["binary_names"],
         )
 
     def to_json(self) -> str:

--- a/tests/test_import_hook/test_project_importer.py
+++ b/tests/test_import_hook/test_project_importer.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import pytest
 
+from maturin_import_hook._resolve_project import has_experimental_inspect
 from maturin_import_hook.project_importer import DefaultProjectFileSearcher, _load_dist_info
 
 from .common import (
@@ -30,6 +31,7 @@ from .common import (
     mixed_test_crate_names,
     remove_ansii_escape_characters,
     remove_executable_from_path,
+    resolved_packages,
     run_concurrent_python,
     run_python,
     run_python_code,
@@ -70,7 +72,7 @@ def _reset_virtualenv() -> Iterator[None]:
 @pytest.mark.parametrize(
     "project_name",
     # path dependencies tested separately
-    sorted(set(all_usable_test_crate_names()) - {"pyo3-mixed-with-path-dep"}),
+    sorted(set(all_usable_test_crate_names()) - {"cffi-mixed-with-path-dep"}),
 )
 def test_install_from_script_inside(workspace: Path, project_name: str) -> None:
     """This test ensures that when a script is run from within a maturin project, the
@@ -101,7 +103,7 @@ def test_install_from_script_inside(workspace: Path, project_name: str) -> None:
     assert _rebuilt_message(project_name) in output1
     assert _up_to_date_message(project_name) not in output1
 
-    assert _is_editable_installed_correctly(project_name, project_dir, "mixed" in project_name)
+    assert _is_editable_installed_correctly(project_name, project_dir, _is_mixed_project(project_name))
 
     output2, duration2 = run_python([str(check_installed_path)], cwd=empty_dir)
     assert "SUCCESS" in output2
@@ -110,7 +112,7 @@ def test_install_from_script_inside(workspace: Path, project_name: str) -> None:
 
     assert duration2 < duration1
 
-    assert _is_editable_installed_correctly(project_name, project_dir, "mixed" in project_name)
+    assert _is_editable_installed_correctly(project_name, project_dir, _is_mixed_project(project_name))
 
 
 @pytest.mark.parametrize("project_name", ["pyo3-mixed", "pyo3-pure"])
@@ -145,7 +147,7 @@ def test_do_not_install_from_script_inside(workspace: Path, project_name: str) -
     assert "SUCCESS" not in output1
 
     _install_editable(project_dir)
-    assert _is_editable_installed_correctly(project_name, project_dir, "mixed" in project_name)
+    assert _is_editable_installed_correctly(project_name, project_dir, _is_mixed_project(project_name))
 
     output2, _ = run_python([str(check_installed_path)], cwd=empty_dir)
     assert "SUCCESS" in output2
@@ -217,7 +219,8 @@ def test_do_not_rebuild_if_installed_non_editable(workspace: Path, project_name:
 @pytest.mark.parametrize(
     "project_name",
     # path dependencies tested separately
-    sorted(set(all_usable_test_crate_names()) - {"pyo3-mixed-with-path-dep"}),
+    # uniffi-multiple-crates: blank template uses directory name as package name, but real project uses "a"
+    sorted(set(all_usable_test_crate_names()) - {"cffi-mixed-with-path-dep", "uniffi-multiple-crates"}),
 )
 def test_import_editable_installed_rebuild(workspace: Path, project_name: str, initially_mixed: bool) -> None:
     """This test ensures that an editable installed project is rebuilt when necessary if the import
@@ -254,7 +257,7 @@ def test_import_editable_installed_rebuild(workspace: Path, project_name: str, i
     assert _rebuilt_message(project_name) in output1
     assert _up_to_date_message(project_name) not in output1
 
-    assert _is_editable_installed_correctly(project_name, project_dir, "mixed" in project_name)
+    assert _is_editable_installed_correctly(project_name, project_dir, _is_mixed_project(project_name))
 
     output2, duration2 = run_python_code(check_installed)
     assert "SUCCESS" in output2
@@ -263,13 +266,13 @@ def test_import_editable_installed_rebuild(workspace: Path, project_name: str, i
 
     assert duration2 < duration1
 
-    assert _is_editable_installed_correctly(project_name, project_dir, "mixed" in project_name)
+    assert _is_editable_installed_correctly(project_name, project_dir, _is_mixed_project(project_name))
 
 
 @pytest.mark.parametrize(
     "project_name",
     # path dependencies tested separately
-    sorted(set(mixed_test_crate_names()) - {"pyo3-mixed-with-path-dep"}),
+    sorted(set(mixed_test_crate_names()) - {"cffi-mixed-with-path-dep"}),
 )
 def test_import_editable_installed_mixed_missing(workspace: Path, project_name: str) -> None:
     """This test ensures that editable installed mixed projects are rebuilt if they are imported
@@ -287,7 +290,7 @@ def test_import_editable_installed_mixed_missing(workspace: Path, project_name: 
     project_backup_dir = _get_project_copy(TEST_CRATES_DIR / project_name, workspace / f"backup_{project_name}")
 
     _install_editable(project_dir)
-    assert _is_editable_installed_correctly(project_name, project_dir, "mixed" in project_name)
+    assert _is_editable_installed_correctly(project_name, project_dir, _is_mixed_project(project_name))
 
     check_installed = TEST_CRATES_DIR / project_name / "check_installed/check_installed.py"
 
@@ -444,7 +447,7 @@ def test_rebuild_on_change_to_path_dependency(workspace: Path) -> None:
     """This test ensures that the imported project is rebuilt if any of its path
     dependencies are edited.
     """
-    project_name = "pyo3-mixed-with-path-dep"
+    project_name = "cffi-mixed-with-path-dep"
     _uninstall(project_name)
 
     project_dir = _get_project_copy(TEST_CRATES_DIR / project_name, workspace / project_name)
@@ -457,12 +460,12 @@ def test_rebuild_on_change_to_path_dependency(workspace: Path) -> None:
     check_installed = "{}\n{}".format(
         IMPORT_HOOK_HEADER,
         dedent("""\
-        import pyo3_mixed_with_path_dep
+        import cffi_mixed_with_path_dep
 
-        assert pyo3_mixed_with_path_dep.get_42() == 42, 'get_42 did not return 42'
+        assert cffi_mixed_with_path_dep.lib.add_21(21) == 42, 'add_21 did not return 42'
 
-        print('21 is half 42:', pyo3_mixed_with_path_dep.is_half(21, 42))
-        print('21 is half 63:', pyo3_mixed_with_path_dep.is_half(21, 63))
+        print('21 is half 42:', cffi_mixed_with_path_dep.lib.is_half(21, 42))
+        print('21 is half 63:', cffi_mixed_with_path_dep.lib.is_half(21, 63))
         """),
     )
 
@@ -552,7 +555,9 @@ def test_low_resolution_mtime(workspace: Path) -> None:
 
     def set_mtimes_equal() -> None:
         s = DefaultProjectFileSearcher()
-        oldest_package_path = min((p for p in s.get_installation_paths(package_path)), key=lambda p: p.stat().st_mtime)
+        oldest_package_path = min(
+            (p for p in s.get_installation_paths([package_path])), key=lambda p: p.stat().st_mtime
+        )
         times = get_file_times(oldest_package_path)
         set_file_times_recursive(package_path, times)
         set_file_times_recursive(source_root, times)
@@ -1204,10 +1209,10 @@ class TestDefaultProjectFileSearcher:
                 source_excluded_dir_markers=set(),
                 source_excluded_file_extensions=set(),
             )
-            assert list(s.get_source_paths(workspace, [], workspace / "missing")) == []
+            assert list(s.get_source_paths(workspace, [], [workspace / "missing"])) == []
             extension_dir = workspace / "extension"
             extension_dir.mkdir()
-            assert list(s.get_source_paths(workspace, [], extension_dir)) == []
+            assert list(s.get_source_paths(workspace, [], [extension_dir])) == []
 
         def test_missing_paths(self, workspace: Path) -> None:
             s = DefaultProjectFileSearcher(
@@ -1217,10 +1222,61 @@ class TestDefaultProjectFileSearcher:
             )
             (workspace / "extension").touch()
             with pytest.raises(FileNotFoundError):
-                list(s.get_source_paths(workspace, [workspace / "missing"], workspace / "extension"))
+                list(s.get_source_paths(workspace, [workspace / "missing"], [workspace / "extension"]))
 
             with pytest.raises(FileNotFoundError):
-                list(s.get_source_paths(workspace / "missing", [], workspace / "extension"))
+                list(s.get_source_paths(workspace / "missing", [], [workspace / "extension"]))
+
+        def test_excluded_dir_names(self, workspace: Path) -> None:
+            s = DefaultProjectFileSearcher(
+                source_excluded_dir_names={"data"},
+                source_excluded_dir_markers=set(),
+                source_excluded_file_extensions=set(),
+            )
+            (workspace / "src").mkdir()
+            (workspace / "src/source_file.rs").touch()
+            (workspace / "src/data").mkdir()
+            (workspace / "src/data/data.rs").touch()
+            (workspace / "src/data/subdir").mkdir()
+            (workspace / "src/data/subdir/more_data.rs").touch()
+
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
+            assert paths == {workspace / "src/source_file.rs"}
+
+        def test_excluded_dir_markers(self, workspace: Path) -> None:
+            s = DefaultProjectFileSearcher(
+                source_excluded_dir_names=set(),
+                source_excluded_dir_markers={".excluded"},
+                source_excluded_file_extensions=set(),
+            )
+            (workspace / "src").mkdir()
+            (workspace / "src/source_file.rs").touch()
+            (workspace / "src/data").mkdir()
+            (workspace / "src/data/data.rs").touch()
+            (workspace / "src/data/subdir").mkdir()
+            (workspace / "src/data/subdir/more_data.rs").touch()
+
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
+            assert paths == {
+                workspace / "src/source_file.rs",
+                workspace / "src/data/data.rs",
+                workspace / "src/data/subdir/more_data.rs",
+            }
+
+            (workspace / "src/data/.excluded").touch()
+
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
+            assert paths == {workspace / "src/source_file.rs"}
+
+            (workspace / "src/data/.excluded").unlink()
+            (workspace / "src/data/.excluded").mkdir()
+
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
+            assert paths == {
+                workspace / "src/source_file.rs",
+                workspace / "src/data/data.rs",
+                workspace / "src/data/subdir/more_data.rs",
+            }
 
         def test_simple(self, workspace: Path) -> None:
             s = DefaultProjectFileSearcher(
@@ -1233,14 +1289,14 @@ class TestDefaultProjectFileSearcher:
             source_file_path = src_dir / "source_file.rs"
             source_file_path.touch()
             (workspace / "extension_module").touch()
-            paths = set(s.get_source_paths(workspace, [], workspace / "extension_module"))
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
             assert paths == {source_file_path}
 
             (workspace / "extension_module").unlink()
             (workspace / "extension_module").mkdir()
             (workspace / "extension_module/stuff").touch()
 
-            paths = set(s.get_source_paths(workspace, [], workspace / "extension_module"))
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
             assert paths == {source_file_path}
 
             s = DefaultProjectFileSearcher(
@@ -1248,7 +1304,7 @@ class TestDefaultProjectFileSearcher:
                 source_excluded_dir_markers=set(),
                 source_excluded_file_extensions=set(),
             )
-            paths = set(s.get_source_paths(workspace, [], workspace / "extension_module"))
+            paths = set(s.get_source_paths(workspace, [], [workspace / "extension_module"]))
             assert paths == set()
 
         def test_simple_path_dep(self, workspace: Path) -> None:
@@ -1270,7 +1326,7 @@ class TestDefaultProjectFileSearcher:
                 source_excluded_dir_markers=set(),
                 source_excluded_file_extensions=set(),
             )
-            paths = set(s.get_source_paths(project_a, [project_b], extension_dir))
+            paths = set(s.get_source_paths(project_a, [project_b], [extension_dir]))
             assert paths == {project_a / "source.py", project_b / "source.py", project_b / "__pycache__/source.pyc"}
 
             s = DefaultProjectFileSearcher(
@@ -1278,7 +1334,7 @@ class TestDefaultProjectFileSearcher:
                 source_excluded_dir_markers=set(),
                 source_excluded_file_extensions=set(),
             )
-            paths = set(s.get_source_paths(project_a, [project_b], extension_dir))
+            paths = set(s.get_source_paths(project_a, [project_b], [extension_dir]))
             assert paths == {project_a / "source.py", project_b / "source.py"}
 
             s = DefaultProjectFileSearcher(
@@ -1286,7 +1342,7 @@ class TestDefaultProjectFileSearcher:
                 source_excluded_dir_markers=set(),
                 source_excluded_file_extensions={".pyc"},
             )
-            paths = set(s.get_source_paths(project_a, [project_b], extension_dir))
+            paths = set(s.get_source_paths(project_a, [project_b], [extension_dir]))
             assert paths == {project_a / "source.py", project_b / "source.py"}
 
         def test_extension_outside_project_source(self, tmp_path: Path) -> None:
@@ -1304,7 +1360,7 @@ class TestDefaultProjectFileSearcher:
                 source_excluded_dir_markers=set(),
                 source_excluded_file_extensions=set(),
             )
-            paths = set(s.get_source_paths(project_dir, [], extension_path))
+            paths = set(s.get_source_paths(project_dir, [], [extension_path]))
             assert paths == {project_dir / "source"}
 
     def test_get_installation_paths(self, workspace: Path) -> None:
@@ -1313,8 +1369,8 @@ class TestDefaultProjectFileSearcher:
             source_excluded_dir_markers=set(),
             source_excluded_file_extensions={".so"},
         )
-        assert set(s.get_installation_paths(workspace)) == set()
-        assert set(s.get_installation_paths(workspace / "missing")) == set()
+        assert set(s.get_installation_paths([workspace])) == set()
+        assert set(s.get_installation_paths([workspace / "missing"])) == set()
 
         (workspace / "extension.so").touch()
         (workspace / "misc").touch()
@@ -1326,8 +1382,8 @@ class TestDefaultProjectFileSearcher:
         (workspace / "__pycache__").mkdir()
         (workspace / "__pycache__/__init__.pyc").touch()
 
-        assert set(s.get_installation_paths(workspace / "extension.so")) == {workspace / "extension.so"}
-        assert set(s.get_installation_paths(workspace)) == {
+        assert set(s.get_installation_paths([workspace / "extension.so"])) == {workspace / "extension.so"}
+        assert set(s.get_installation_paths([workspace])) == {
             workspace / "extension.so",
             workspace / "misc",
             workspace / "subdir/file.py",
@@ -1419,17 +1475,41 @@ def test_non_directory_in_search_path(tmp_path: Path) -> None:
         assert not file_in_sys_path, "sys.path should only contain the script file path on Windows"
 
 
+def _get_package_name(project_name: str) -> str:
+    """Get the actual package name for a test crate.
+
+    For most crates, the package name is derived from the directory name (with hyphens replaced by underscores).
+    However, some crates (like uniffi-multiple-crates) have package names that differ from their directory names.
+    This function looks up the correct name from resolved_packages().
+    """
+    resolved = resolved_packages().get(project_name)
+    if resolved is not None and resolved.module_full_name:
+        # module_full_name is the full dotted module name (e.g. "a" or "cffi_mixed.rust_module.rust")
+        # The top-level module name is what the import hook uses in its log messages
+        return resolved.module_full_name.split(".")[0]
+    return with_underscores(project_name)
+
+
 def _up_to_date_message(project_name: str) -> str:
-    return f'package up to date: "{with_underscores(project_name)}"'
+    return f'package up to date: "{_get_package_name(project_name)}"'
 
 
 def _rebuilt_message(project_name: str) -> str:
-    return f'rebuilt and loaded package "{with_underscores(project_name)}"'
+    return f'rebuilt and loaded package "{_get_package_name(project_name)}"'
 
 
 def _uninstall(project_name: str) -> None:
     installer = PackageInstaller.from_env()
-    installer.uninstall(project_name)
+    installer.uninstall(_get_package_name(project_name))
+
+
+def _is_mixed_project(project_name: str) -> bool:
+    """
+    Check if a project is a mixed project (has a Python module directory alongside Rust code).
+
+    Mixed projects and bin projects with Python modules both install .pth files.
+    """
+    return "mixed" in project_name or "bin-" in project_name
 
 
 def _install_editable(project_dir: Path) -> None:
@@ -1443,6 +1523,8 @@ def _install_editable(project_dir: Path) -> None:
     cmd = [maturin_path, "develop"]
     if PackageInstallerBackend.from_env() == PackageInstallerBackend.UV:
         cmd.append("--uv")
+    if has_experimental_inspect(project_dir):
+        cmd.append("--generate-stubs")
     subprocess.check_call(cmd, cwd=project_dir, env=env)
 
 
@@ -1453,12 +1535,12 @@ def _install_non_editable(project_dir: Path) -> None:
 
 
 def _is_installed_as_pth(project_name: str) -> bool:
-    package_name = with_underscores(project_name)
+    package_name = _get_package_name(project_name)
     return any((Path(path) / f"{package_name}.pth").exists() for path in site.getsitepackages())
 
 
 def _is_installed_editable_with_direct_url(project_name: str, project_dir: Path) -> bool:
-    package_name = with_underscores(project_name)
+    package_name = _get_package_name(project_name)
     for path in site.getsitepackages():
         linked_path, is_editable = _load_dist_info(Path(path), package_name)
         if linked_path == project_dir:

--- a/tests/test_import_hook/test_utilities.py
+++ b/tests/test_import_hook/test_utilities.py
@@ -35,12 +35,12 @@ def test_maturin_unchanged() -> None:
     env = {"PATH": os.environ["PATH"], "COLUMNS": "120"}
 
     build_help = subprocess.check_output("stty rows 50 cols 120; maturin build --help", shell=True, env=env)  # noqa: S602
-    assert hashlib.sha1(build_help).hexdigest() == "ea47a884c90c9376047687aed98ab1dca29b433a", (
+    assert hashlib.sha1(build_help).hexdigest() == "310099f8b71a70563d1d0bdd5cb72a3040f16cd5", (
         f"hashes don't match. build_help = {build_help!r}"
     )
 
     develop_help = subprocess.check_output("stty rows 50 cols 120; maturin develop --help", shell=True, env=env)  # noqa: S602
-    assert hashlib.sha1(develop_help).hexdigest() == "ad7036a829c6801224933d589b1f9848678c9458", (
+    assert hashlib.sha1(develop_help).hexdigest() == "64a9a80feeaf0ef81c3500bddee40a6f0a5377bd", (
         f"hashes don't match. develop_help = {develop_help!r}"
     )
 
@@ -68,9 +68,10 @@ def test_settings() -> None:
         unstable_flags=["unstable1", "unstable2"],
         verbose=2,
         rustc_flags=["flag1", "--flag2"],
+        generate_stubs=True,
     )
     # fmt: off
-    expected_args = [
+    expected_common_args = [
         "--release",
         "--strip",
         "--quiet",
@@ -90,15 +91,25 @@ def test_settings() -> None:
         "-Z", "unstable1",
         "-Z", "unstable2",
         "-vv",
+    ]
+    # fmt: on
+    expected_develop_args = [
+        *expected_common_args,
+        "--generate-stubs",
         "--",
         "flag1",
         "--flag2",
     ]
-    # fmt: on
-    assert settings.to_args("develop") == expected_args
-    assert settings.to_args("build") == expected_args
+    expected_build_args = [
+        *expected_common_args,
+        "--",
+        "flag1",
+        "--flag2",
+    ]
+    assert settings.to_args("develop") == expected_develop_args
+    assert settings.to_args("build") == expected_build_args
 
-    assert MaturinSettings.from_args(expected_args) == settings
+    assert MaturinSettings.from_args(expected_develop_args) == settings
 
     build_settings = MaturinSettings(auditwheel="skip", zig=True)
     expected_args = [
@@ -112,11 +123,14 @@ def test_settings() -> None:
 
     develop_settings = MaturinSettings(
         extras=["extra1", "extra2"],
+        group=["group1", "group2"],
         skip_install=True,
     )
     expected_args = [
         "--extras",
         "extra1,extra2",
+        "--group",
+        "group1,group2",
         "--skip-install",
     ]
     assert develop_settings.to_args("develop") == expected_args
@@ -126,6 +140,7 @@ def test_settings() -> None:
     mixed_settings = MaturinSettings(
         color=True,
         extras=["extra1", "extra2"],
+        group=["group1", "group2"],
         skip_install=True,
         zig=True,
         rustc_flags=["flag1", "--flag2"],
@@ -135,6 +150,8 @@ def test_settings() -> None:
         "always",
         "--extras",
         "extra1,extra2",
+        "--group",
+        "group1,group2",
         "--skip-install",
         "--",
         "flag1",
@@ -335,6 +352,8 @@ def test_resolve_project(project_name: str) -> None:
             python_module=map_optional(resolved.python_module, _relative_path),
             extension_module_dir=map_optional(resolved.extension_module_dir, _relative_path),
             module_full_name=resolved.module_full_name,
+            bindings=resolved.bindings,
+            binary_names=resolved.binary_names,
         )
     log.info("calculated:")
     log.info(map_optional(calculated, lambda x: x.to_json()))


### PR DESCRIPTION
upgrade to maturin 1.14.1

- the version bump introduces `--generate-stubs` and `--groups` to the maturin cli
- stub generation is handled by excluding `.pyi` from being considered a 'source file' by the import hook by default. This prevents the build from always being stale when `--generate-stubs` is used
- `--generate-stubs` is enabled by default if the project uses the `experimental-inspect` feature
- the new maturin version has several different test-crates from what was used previously. This PR includes many fixes to work with the new test crates including adding support for `bindings = "bin"` projects.
- adds missing tests mentioned here https://github.com/PyO3/maturin-import-hook/pull/27